### PR TITLE
feat: enable tmux mouse mode for scrolling and pane interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Or add manually to `~/.tmux.conf`:
 ```bash
 set -g status-right "Claude: #(rocha status) | %H:%M"
 set -g status-interval 1
+set -g mouse on  # Enable mouse support
 ```
 
 ## Requirements

--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,7 @@
 - [ ] Allow mouse selection on the session list
 - [ ] Implement copy/paste functionality
 - [ ] Allow filtering session list with sticky filters
-- [ ] Configure tmux to allow mouse scroll
+- [x] Configure tmux to allow mouse scroll
 
 ## Configuration and State Management
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -19,6 +19,7 @@ const (
 set -g status-left-length 50  # Allow longer session names
 set -g status-right "Claude: #(rocha status) | %H:%M"
 set -g status-interval 1  # Update every 1 second
+set -g mouse on  # Enable mouse support (scrolling, pane selection, resizing)
 `
 	pathMarker = "# Added by rocha setup"
 )
@@ -129,6 +130,7 @@ func (s *SetupCmd) setupTmux(tmuxClient tmux.Client, homeDir string) error {
 		{"status-left-length", "set -g status-left-length 50  # Allow longer session names\n"},
 		{"rocha status", "set -g status-right \"Claude: #(rocha status) | %H:%M\"\n"},
 		{"status-interval", "set -g status-interval 1  # Update every 1 second\n"},
+		{"mouse on", "set -g mouse on  # Enable mouse support (scrolling, pane selection, resizing)\n"},
 	}
 
 	var missingSettings []string


### PR DESCRIPTION
## Summary
- Adds mouse support configuration to the tmux setup command
- Enables mouse scrolling, pane selection, and pane resizing
- Updates setup to idempotently configure mouse mode
- Documents mouse configuration in README

## Changes
- **cmd/setup.go**: Added `set -g mouse on` to tmux configuration
- **README.md**: Updated manual setup instructions to include mouse mode
- **TODO.md**: Marked mouse scroll configuration as complete

## Test plan
- [ ] Run `rocha setup` on a fresh system and verify mouse mode is enabled
- [ ] Verify mouse scrolling works in tmux panes
- [ ] Verify pane selection and resizing works with mouse
- [ ] Verify idempotent behavior (running setup twice doesn't duplicate settings)