### PR TITLE
fix: display session creation errors to users

### DIFF
--- a/ui/model.go
+++ b/ui/model.go
@@ -389,6 +389,12 @@ func (m Model) updateCreatingSession(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.state = stateList
 		m.sessionForm = nil
 
+		// Check if session creation failed
+		if result.Error != nil {
+			m.err = fmt.Errorf("failed to create session: %w", result.Error)
+			return m, nil
+		}
+
 		if !result.Cancelled {
 			// Reload session state (source of truth)
 			sessionState, err := state.Load()

--- a/ui/session_form.go
+++ b/ui/session_form.go
@@ -20,6 +20,7 @@ type SessionFormResult struct {
 	BranchName     string
 	CreateWorktree bool
 	Cancelled      bool
+	Error          error // Error that occurred during session creation
 }
 
 // SessionForm is a Bubble Tea component for creating sessions
@@ -111,7 +112,7 @@ func (sf *SessionForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Create the session
 		if err := sf.createSession(); err != nil {
 			logging.Logger.Error("Failed to create session", "error", err)
-			// TODO: Handle error better
+			sf.result.Error = err // Store error in result so it can be displayed to user
 		}
 		return sf, nil
 	}


### PR DESCRIPTION
## Summary

- Session creation errors are now properly displayed to users in the TUI instead of being silently logged
- Added Error field to SessionFormResult struct for error propagation through the form completion flow
- Errors appear in red at the bottom of the session list, consistent with existing error display patterns

## Test plan

- [ ] Test session creation with invalid worktree path (should display error)
- [ ] Test session creation with invalid branch name (should display error)
- [ ] Test session creation when tmux fails (should display error)
- [ ] Verify error messages include full context via error wrapping
- [ ] Confirm successful session creation still works normally
- [ ] Verify cancelled session creation doesn't show errors