### PR TITLE
feat: add GoReleaser with GitHub Actions for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.6'
+
+      - name: Set Go version environment variable
+        run: echo "GOVERSION=$(go version | awk '{print $3}')" >> $GITHUB_ENV
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /rocha
 debug.log
+
+# GoReleaser output
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,69 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: rocha
+    binary: rocha
+    main: ./main.go
+
+    goos:
+      - linux
+      - darwin
+
+    goarch:
+      - amd64
+      - arm64
+
+    ldflags:
+      - -s -w
+      - -X rocha/version.Version={{.Version}}
+      - -X rocha/version.Commit={{.Commit}}
+      - -X rocha/version.Date={{.Date}}
+      - -X rocha/version.GoVersion={{.Env.GOVERSION}}
+
+    env:
+      - CGO_ENABLED=0
+
+archives:
+  - id: rocha
+    format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- .Arch }}
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: 'checksums.txt'
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - Merge pull request
+      - Merge branch
+  groups:
+    - title: Features
+      regexp: '^feat.*:'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^fix.*:'
+      order: 1
+    - title: Others
+      order: 999
+
+release:
+  github:
+  draft: false
+  prerelease: auto
+  mode: replace

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -275,9 +275,10 @@ Structured logging with slog (used by cmd, ui, tmux).
 - Non-blocking operation tracing
 
 #### version/
-Version and tagline constants (used by ui).
-- Build-time version information
+Version and build metadata (used by cmd, ui).
+- Build-time version injection (Version, Commit, Date, GoVersion)
 - Application tagline for display
+- Injectable via ldflags during compilation
 
 ## Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+.PHONY: build install clean snapshot help
+
+# Build variables
+VERSION ?= dev
+COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+GOVERSION := $(shell go version | awk '{print $$3}')
+
+LDFLAGS := -X rocha/version.Version=$(VERSION) \
+           -X rocha/version.Commit=$(COMMIT) \
+           -X rocha/version.Date=$(DATE) \
+           -X rocha/version.GoVersion=$(GOVERSION)
+
+help:
+	@echo "Available targets:"
+	@echo "  build     - Build rocha binary with version information"
+	@echo "  install   - Build and install to ~/.local/bin"
+	@echo "  snapshot  - Test GoReleaser locally (no publish)"
+	@echo "  clean     - Remove built binaries and dist/"
+
+build:
+	@echo "Building rocha..."
+	go build -ldflags "$(LDFLAGS)" -o rocha .
+	@echo "Build complete: ./rocha"
+
+install: build
+	@echo "Installing to ~/.local/bin/rocha..."
+	@mkdir -p ~/.local/bin
+	@cp rocha ~/.local/bin/rocha
+	@echo "Installation complete"
+
+snapshot:
+	@echo "Running GoReleaser in snapshot mode..."
+	goreleaser release --snapshot --clean
+	@echo "Snapshot build complete in dist/"
+
+clean:
+	@echo "Cleaning..."
+	@rm -f rocha
+	@rm -rf dist/
+	@echo "Clean complete"

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ I'm Rocha, and I manage coding agents
 
 ```bash
 # Build and install
-go build -o rocha
-cp rocha ~/.local/bin/
+make install
 
 # Set up PATH and tmux status bar
 rocha setup
@@ -69,12 +68,56 @@ set -g status-interval 1
 set -g mouse on  # Enable mouse support
 ```
 
+## Building from Source
+
+### Prerequisites
+- Go 1.25.6 or later
+- Git
+
+### Using Make (recommended)
+```bash
+make build          # Build with version info
+make install        # Build and install to ~/.local/bin
+make snapshot       # Test release build locally
+```
+
+### Using Go directly
+```bash
+go build -o rocha .
+```
+
+### Check Version
+```bash
+rocha --version
+```
+
+## Release Process (for maintainers)
+
+Releases are automated via GitHub Actions:
+
+1. Create and push a version tag:
+   ```bash
+   git tag -a v1.0.0 -m "Release v1.0.0"
+   git push origin v1.0.0
+   ```
+
+2. GitHub Actions automatically:
+   - Builds binaries for linux/darwin on amd64/arm64
+   - Creates a GitHub release with changelog
+   - Uploads binaries and checksums
+
+3. Test locally before tagging:
+   ```bash
+   make snapshot
+   ./dist/rocha_linux_amd64_v1/rocha --version
+   ```
+
 ## Requirements
 
 - tmux
 - git (for worktree support)
 - Claude Code CLI (`claude`)
-- Go 1.16+ (for building)
+- Go 1.25.6+ (for building from source)
 
 ## Troubleshooting
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,14 +12,16 @@ import (
 	"rocha/tmux"
 	"rocha/ui"
 
+	"github.com/alecthomas/kong"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
 // CLI represents the command-line interface structure
 type CLI struct {
-	Debug        bool   `help:"Enable debug logging to file" short:"d"`
-	DebugFile    string `help:"Custom path for debug log file (disables automatic cleanup)"`
-	MaxLogFiles  int    `help:"Maximum number of log files to keep (0 = unlimited)" default:"1000"`
+	Version      kong.VersionFlag `help:"Show version information"`
+	Debug        bool             `help:"Enable debug logging to file" short:"d"`
+	DebugFile    string           `help:"Custom path for debug log file (disables automatic cleanup)"`
+	MaxLogFiles  int              `help:"Maximum number of log files to keep (0 = unlimited)" default:"1000"`
 
 	Run         RunCmd         `cmd:"" help:"Start the rocha TUI (default)" default:"1"`
 	Setup       SetupCmd       `cmd:"setup" help:"Configure tmux status bar integration automatically"`

--- a/main.go
+++ b/main.go
@@ -19,6 +19,9 @@ func main() {
 	ctx := kong.Parse(&cli,
 		kong.Name("rocha"),
 		kong.Description(version.Tagline),
+		kong.Vars{
+			"version": version.Info(),
+		},
 		kong.UsageOnError(),
 		kong.BindTo(tmuxClient, (*tmux.Client)(nil)),
 	)

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,20 @@
 package version
 
+import "fmt"
+
 // Tagline is the application's tagline used in help text and documentation
 const Tagline = "I'm Rocha, and I manage coding agents"
+
+// Build information injected at build time via ldflags
+var (
+	Version   = "dev"      // Semantic version or "dev"
+	Commit    = "unknown"  // Git commit hash
+	Date      = "unknown"  // Build date (RFC3339)
+	GoVersion = "unknown"  // Go version used
+)
+
+// Info returns formatted version information
+func Info() string {
+	return fmt.Sprintf("rocha %s (commit: %s, built: %s, go: %s)",
+		Version, Commit, Date, GoVersion)
+}


### PR DESCRIPTION
## Summary

Implements automated multi-platform releases with comprehensive version tracking:

- **Version package enhancements**: Adds build metadata variables (Version, Commit, Date, GoVersion) injectable via ldflags
- **CLI version flag**: Adds `--version` flag to display build information
- **Makefile**: Provides convenient targets (build, install, snapshot, clean) with automatic version injection
- **GoReleaser configuration**: Builds for linux/darwin on amd64/arm64 with static binaries
- **GitHub Actions workflow**: Automates releases when version tags are pushed
- **Documentation updates**: Comprehensive build and release process documentation

## Changes

### Core Functionality
- `version/version.go`: Added build metadata variables and Info() function
- `main.go`: Wired version.Info() into Kong CLI
- `cmd/root.go`: Added Version field with kong.VersionFlag

### Build & Release Infrastructure
- `Makefile`: Local build automation with version injection
- `.goreleaser.yaml`: Multi-platform release configuration
- `.github/workflows/release.yml`: GitHub Actions automation

### Documentation
- `README.md`: Added "Building from Source" and "Release Process" sections
- `ARCHITECTURE.md`: Updated version package description
- `.gitignore`: Excluded dist/ directory

## Build Configuration

**Platforms**: linux/darwin on amd64/arm64
**Features**: Static binaries (CGO_ENABLED=0), stripped debug info (-s -w)
**Archives**: Include LICENSE and README.md
**Changelog**: Automatic generation from conventional commits

## Test Plan

- [x] Build binary with `make build`
- [x] Verify version flag: `./rocha --version` displays correct info
- [x] Install binary with `make install`
- [x] Verify installed binary works: `~/.local/bin/rocha --help`
- [ ] Test GoReleaser locally: `make snapshot`
- [ ] Create test tag and verify GitHub Actions workflow
- [ ] Verify release artifacts are created correctly

## Release Process

Once merged, create releases by:
```bash
git tag -a v1.0.0 -m "Release v1.0.0"
git push origin v1.0.0
```

GitHub Actions will automatically build and publish the release.