### PR TITLE
fix: prevent session creation without git metadata from hook events

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -226,12 +226,12 @@ func applyEvent(state *SessionState, event StateEvent) error {
 			existing.LastUpdated = event.Timestamp
 			state.Sessions[event.SessionName] = existing
 		} else {
-			state.Sessions[event.SessionName] = SessionInfo{
-				Name:        event.SessionName,
-				State:       event.State,
-				ExecutionID: event.ExecutionID,
-				LastUpdated: event.Timestamp,
-			}
+			// Don't create new sessions from update events - sessions should only be created
+			// via UpdateSessionWithGit() or git detection during startup. This prevents
+			// race conditions where hook events arrive before git metadata is saved.
+			logging.Logger.Warn("Ignoring update event for non-existent session",
+				"session", event.SessionName,
+				"state", event.State)
 		}
 
 	case "sync_running":


### PR DESCRIPTION
## Summary

Fixes a race condition where hook events could create sessions in state before git metadata (branch name, repo info) was saved. This caused sessions to appear in the list without branch information, resulting in the "branches started to not show in the list" issue.

## Root Cause

When hooks fire immediately after tmux session creation (e.g., "start" or "prompt" events from Claude), the `QueueUpdateSession()` call would queue an update event without git metadata. If this event was processed by `applyEvent()` before `UpdateSessionWithGit()` completed, it would create a session entry WITHOUT branch information.

## The Fix

Modified `state/state.go:228-235` in the `applyEvent()` function to:
- Only update existing sessions when processing "update_session" events
- Ignore update events for non-existent sessions with a warning log
- Ensure sessions are created only through:
  - Explicit calls to `UpdateSessionWithGit()` (during session creation)
  - Git detection during startup (recovery mechanism)

## Changes

- `state/state.go`: Replaced session creation logic in `applyEvent()` with warning log for non-existent sessions

## Test Plan

- [x] Build binary successfully
- [ ] Create multiple sessions rapidly and verify all show branch information
- [ ] Check state.json to confirm all sessions have `branch_name` and `repo_info` fields
- [ ] Restart rocha and verify branches still display correctly
- [ ] Monitor logs for "Ignoring update event for non-existent session" warnings