### PR TITLE
fix: prevent UI freeze during session creation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -124,6 +124,7 @@ classDiagram
         +Update()
         +View()
         +Result()
+        +createSessionCmd() "Async creation"
     }
 
     DefaultClient ..|> Client
@@ -148,15 +149,19 @@ classDiagram
 sequenceDiagram
     participant User
     participant TUI
+    participant Cmd as tea.Cmd<br/>(Background)
     participant Tmux
     participant State
     participant Git
 
     User->>TUI: Create session
-    TUI->>Git: Create worktree
-    TUI->>Tmux: Create tmux session
-    TUI->>State: Save metadata
+    TUI->>Cmd: createSessionCmd()
+    Note over TUI: UI remains responsive
+    Cmd->>Git: Create worktree
+    Cmd->>Tmux: Create tmux session
+    Cmd->>State: Save metadata
     State->>State: Write state.json
+    Cmd->>TUI: sessionCreatedMsg
 
     User->>TUI: Attach to session
     TUI->>Tmux: Attach


### PR DESCRIPTION
## Summary

- Moves session creation to background goroutine using Bubble Tea's command pattern
- UI remains responsive during git operations (pull/rebase, worktree creation) and tmux setup
- Adds animated spinner component to provide visual feedback during creation

## Technical Details

The issue was that `createSession()` was being called synchronously in the UI update cycle, blocking all rendering and input processing while:
- Git operations executed (potentially slow over network)
- Tmux session was created and polled (up to 2s timeout)
- State files were written

The fix implements the standard Bubble Tea async pattern:
1. `createSessionCmd()` returns a `tea.Cmd` that runs in a background goroutine
2. When complete, sends `sessionCreatedMsg` back to the UI
3. Spinner animates during creation using `bubbles/spinner`

## Test plan

- [ ] Run `rocha-lisbon` (or rebuild from source)
- [ ] Press 'n' to create a new session
- [ ] Fill out the form and submit
- [ ] Verify UI shows animated spinner immediately
- [ ] Verify you can see the spinner animation (UI not frozen)
- [ ] Verify session is created successfully after 2-3 seconds
- [ ] Test with both worktree creation enabled and disabled
- [ ] Test canceling with Esc during form input