### PR TITLE
feat: add editor opening from session list with 'o' key

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,6 +18,7 @@ graph TB
         TMUX[Tmux Client<br/>tmux/]
         STATE[State Manager<br/>state/]
         GIT[Git Operations<br/>git/]
+        EDITOR[Editor Opener<br/>editor/]
     end
 
     subgraph "Cross-Cutting Concerns"
@@ -39,6 +40,7 @@ graph TB
     TUI --> TMUX
     TUI --> STATE
     TUI --> GIT
+    TUI --> EDITOR
     TMUX --> TMUXCLI
     STATE --> FS
     GIT --> GITCLI
@@ -271,6 +273,12 @@ Git worktree operations.
 - Branch detection
 - Repository metadata extraction
 
+#### editor/
+Editor integration with platform-specific defaults.
+- Build-tag based platform detection (linux, darwin, windows)
+- Fallback chain: CLI flag → `$ROCHA_EDITOR` → `$VISUAL` → `$EDITOR` → platform defaults
+- Non-blocking editor launch
+
 ### Cross-Cutting Concerns
 
 #### logging/
@@ -301,6 +309,7 @@ graph LR
         TMUX[tmux]
         GIT[git]
         CLAUDE[claude<br/>Claude Code CLI]
+        CODE[code<br/>VS Code/Editor]
     end
 
     APP[Rocha] --> KONG
@@ -311,6 +320,7 @@ graph LR
     APP --> TMUX
     APP --> GIT
     APP -.-> CLAUDE
+    APP -.-> CODE
 ```
 
 **Go Libraries:**
@@ -326,6 +336,7 @@ graph LR
 - `tmux` - Terminal multiplexer (required)
 - `git` - Version control (required for worktrees)
 - `claude` - Claude Code CLI (bootstrapped automatically, dotted line indicates it's spawned not directly called)
+- `code` - VS Code or other editor (optional, dotted line indicates it's spawned via 'o' key, falls back to shell)
 
 
 <!-- Keep this document more visual than textual, an image is better than 1000 words -->

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,7 @@ func (c *CLI) AfterApply() error {
 // RunCmd starts the TUI application
 type RunCmd struct {
 	WorktreePath string `help:"Base directory for git worktrees" type:"path" default:"~/.rocha/worktrees"`
+	Editor       string `help:"Editor to open sessions in (overrides $ROCHA_EDITOR, $VISUAL, $EDITOR)" default:"code"`
 }
 
 // Run executes the TUI
@@ -166,7 +167,7 @@ func (r *RunCmd) Run(tmuxClient tmux.Client) error {
 	// Set terminal to raw mode for proper input handling
 	logging.Logger.Debug("Initializing Bubble Tea program")
 	p := tea.NewProgram(
-		ui.NewModel(tmuxClient, r.WorktreePath),
+		ui.NewModel(tmuxClient, r.WorktreePath, r.Editor),
 		tea.WithAltScreen(),       // Use alternate screen buffer
 		tea.WithMouseCellMotion(), // Enable mouse support
 	)

--- a/editor/opener.go
+++ b/editor/opener.go
@@ -1,0 +1,69 @@
+package editor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"rocha/logging"
+)
+
+// OpenInEditor opens the specified directory in an editor
+// Priority: cliEditor → $ROCHA_EDITOR → $VISUAL → $EDITOR → platform defaults
+func OpenInEditor(path string, cliEditor string) error {
+	if path == "" {
+		return fmt.Errorf("no path provided")
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("path does not exist: %w", err)
+	}
+
+	editor, args := findEditor(path, cliEditor)
+	if editor == "" {
+		return fmt.Errorf("no suitable editor found. Set --editor flag, $ROCHA_EDITOR, $VISUAL, or $EDITOR")
+	}
+
+	logging.Logger.Info("Opening editor", "editor", editor, "path", path)
+
+	cmd := exec.Command(editor, args...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start editor: %w", err)
+	}
+
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			logging.Logger.Warn("Editor exited with error", "error", err, "editor", editor)
+		}
+	}()
+
+	return nil
+}
+
+func findEditor(path string, cliEditor string) (string, []string) {
+	// 1. CLI flag takes precedence
+	if cliEditor != "" {
+		return cliEditor, []string{path}
+	}
+
+	// 2. Check ROCHA_EDITOR
+	if editor := os.Getenv("ROCHA_EDITOR"); editor != "" {
+		return editor, []string{path}
+	}
+
+	// 3. Check VISUAL
+	if editor := os.Getenv("VISUAL"); editor != "" {
+		return editor, []string{path}
+	}
+
+	// 4. Check EDITOR
+	if editor := os.Getenv("EDITOR"); editor != "" {
+		return editor, []string{path}
+	}
+
+	// 5. Platform-specific defaults
+	return findPlatformEditor(path)
+}

--- a/editor/opener_darwin.go
+++ b/editor/opener_darwin.go
@@ -1,0 +1,39 @@
+//go:build darwin
+
+package editor
+
+import (
+	"os"
+	"os/exec"
+)
+
+var defaultEditors = []string{
+	"code",
+	"code-insiders",
+	"cursor",
+}
+
+func findPlatformEditor(path string) (string, []string) {
+	for _, editor := range defaultEditors {
+		if _, err := exec.LookPath(editor); err == nil {
+			return editor, []string{path}
+		}
+	}
+
+	apps := []string{
+		"/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+		"/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+	}
+
+	for _, app := range apps {
+		if _, err := os.Stat(app); err == nil {
+			return app, []string{path}
+		}
+	}
+
+	shell := "/bin/sh"
+	if s := os.Getenv("SHELL"); s != "" {
+		shell = s
+	}
+	return shell, []string{"-c", "cd " + path + " && exec $SHELL"}
+}

--- a/editor/opener_default.go
+++ b/editor/opener_default.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin && !windows
+
+package editor
+
+import "os"
+
+func findPlatformEditor(path string) (string, []string) {
+	shell := "/bin/sh"
+	if s := os.Getenv("SHELL"); s != "" {
+		shell = s
+	}
+	return shell, []string{"-c", "cd " + path + " && exec $SHELL"}
+}

--- a/editor/opener_linux.go
+++ b/editor/opener_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package editor
+
+import (
+	"os"
+	"os/exec"
+)
+
+var defaultEditors = []string{
+	"code",
+	"code-insiders",
+	"cursor",
+	"codium",
+	"subl",
+	"zed",
+}
+
+func findPlatformEditor(path string) (string, []string) {
+	for _, editor := range defaultEditors {
+		if _, err := exec.LookPath(editor); err == nil {
+			return editor, []string{path}
+		}
+	}
+
+	// Fallback: open shell in directory
+	shell := "/bin/sh"
+	if s := os.Getenv("SHELL"); s != "" {
+		shell = s
+	}
+	return shell, []string{"-c", "cd " + path + " && exec $SHELL"}
+}

--- a/editor/opener_windows.go
+++ b/editor/opener_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package editor
+
+import (
+	"os/exec"
+)
+
+var defaultEditors = []string{
+	"code.cmd",
+	"code-insiders.cmd",
+	"cursor.cmd",
+}
+
+func findPlatformEditor(path string) (string, []string) {
+	for _, editor := range defaultEditors {
+		if _, err := exec.LookPath(editor); err == nil {
+			return editor, []string{path}
+		}
+	}
+
+	return "cmd.exe", []string{"/K", "cd", "/D", path}
+}


### PR DESCRIPTION
## Summary
- Add keyboard shortcut 'o' to open editor in session's worktree directory
- New editor/ package with platform-specific defaults (Linux, macOS, Windows)
- Configuration priority: --editor flag → $ROCHA_EDITOR → $VISUAL → $EDITOR → platform defaults
- Default editor set to 'code' (VS Code)
- Non-blocking editor launch

## Features
- Press 'o' on any session to open its worktree in your editor
- Configurable via `--editor` flag or environment variables
- Falls back to shell if no editor found
- Shows error if session has no worktree

## Platform Defaults
- **Linux**: code, cursor, codium, subl, zed
- **macOS**: code, cursor (with app bundle paths)
- **Windows**: .cmd versions

## Test plan
- [x] Build and install binary
- [x] Test 'o' key opens VS Code in worktree directory
- [x] Test error handling for sessions without worktrees
- [x] Update ARCHITECTURE.md with editor package

## Changes
- Added `editor/` package with build-tag based platform detection
- Modified `cmd/root.go` to add `--editor` flag (default: "code")
- Modified `ui/model.go` to handle editor opening
- Modified `ui/session_list.go` to add 'o' key handler
- Updated help text to show "o: open editor"
- Updated ARCHITECTURE.md with editor package documentation