### PR TITLE
fix: improve error display with fixed reserved space

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 	"rocha/git"
 	"rocha/logging"
 	"rocha/state"
@@ -58,8 +59,9 @@ func (c *CLI) AfterApply() error {
 
 // RunCmd starts the TUI application
 type RunCmd struct {
-	WorktreePath string `help:"Base directory for git worktrees" type:"path" default:"~/.rocha/worktrees"`
-	Editor       string `help:"Editor to open sessions in (overrides $ROCHA_EDITOR, $VISUAL, $EDITOR)" default:"code"`
+	WorktreePath    string `help:"Base directory for git worktrees" type:"path" default:"~/.rocha/worktrees"`
+	Editor          string `help:"Editor to open sessions in (overrides $ROCHA_EDITOR, $VISUAL, $EDITOR)" default:"code"`
+	ErrorClearDelay int    `help:"Seconds before error messages auto-clear" default:"10"`
 }
 
 // Run executes the TUI
@@ -166,8 +168,9 @@ func (r *RunCmd) Run(tmuxClient tmux.Client) error {
 
 	// Set terminal to raw mode for proper input handling
 	logging.Logger.Debug("Initializing Bubble Tea program")
+	errorClearDelay := time.Duration(r.ErrorClearDelay) * time.Second
 	p := tea.NewProgram(
-		ui.NewModel(tmuxClient, r.WorktreePath, r.Editor),
+		ui.NewModel(tmuxClient, r.WorktreePath, r.Editor, errorClearDelay),
 		tea.WithAltScreen(),       // Use alternate screen buffer
 		tea.WithMouseCellMotion(), // Enable mouse support
 	)

--- a/ui/errors.go
+++ b/ui/errors.go
@@ -1,0 +1,114 @@
+package ui
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	maxErrorLines  = 2
+	errorPrefix    = "Error: "
+	truncationMark = "..."
+)
+
+// formatErrorForDisplay formats an error message for TUI display.
+// It limits the error to maxErrorLines (2 lines) and wraps text based on terminal width.
+// The function accounts for the "Error: " prefix when calculating line width.
+// If the error message is too long, it truncates with "..." at the end.
+func formatErrorForDisplay(err error, maxWidth int) string {
+	if err == nil {
+		return ""
+	}
+
+	// Get the error message
+	message := err.Error()
+	if message == "" {
+		return errorPrefix + "unknown error"
+	}
+
+	// Calculate available width per line (accounting for "Error: " prefix on first line)
+	firstLineWidth := maxWidth - utf8.RuneCountInString(errorPrefix)
+	if firstLineWidth < 10 {
+		firstLineWidth = 10 // Minimum width to prevent edge cases
+	}
+
+	otherLineWidth := maxWidth
+	if otherLineWidth < 10 {
+		otherLineWidth = 10
+	}
+
+	// Split message into words
+	words := strings.Fields(message)
+	if len(words) == 0 {
+		return errorPrefix + message
+	}
+
+	// Build lines
+	var lines []string
+	var currentLine strings.Builder
+	currentLineWidth := firstLineWidth
+
+	for _, word := range words {
+		wordLen := utf8.RuneCountInString(word)
+		currentLen := utf8.RuneCountInString(currentLine.String())
+
+		// Check if adding this word would exceed the current line width
+		if currentLen > 0 && currentLen+1+wordLen > currentLineWidth {
+			// Save current line and start a new one
+			lines = append(lines, currentLine.String())
+			currentLine.Reset()
+
+			// Check if we've reached max lines
+			if len(lines) >= maxErrorLines {
+				break
+			}
+
+			// Switch to other line width after first line
+			currentLineWidth = otherLineWidth
+		}
+
+		// Add word to current line
+		if currentLine.Len() > 0 {
+			currentLine.WriteString(" ")
+		}
+		currentLine.WriteString(word)
+	}
+
+	// Add the last line if there's content and we haven't exceeded max lines
+	if currentLine.Len() > 0 && len(lines) < maxErrorLines {
+		lines = append(lines, currentLine.String())
+	}
+
+	// If we have exactly maxErrorLines and there are more words, add truncation mark
+	if len(lines) == maxErrorLines && len(words) > 0 {
+		lastLine := lines[maxErrorLines-1]
+		truncLen := utf8.RuneCountInString(truncationMark)
+
+		// If the last line is too long, truncate it to make room for "..."
+		if utf8.RuneCountInString(lastLine)+truncLen > otherLineWidth {
+			// Calculate how many runes we can keep
+			maxRunes := otherLineWidth - truncLen
+			if maxRunes > 0 {
+				runes := []rune(lastLine)
+				if len(runes) > maxRunes {
+					lastLine = string(runes[:maxRunes])
+				}
+			}
+		}
+
+		lines[maxErrorLines-1] = lastLine + truncationMark
+	}
+
+	// Combine lines with newlines
+	if len(lines) == 0 {
+		return errorPrefix
+	}
+
+	// Add "Error: " prefix to first line
+	result := errorPrefix + lines[0]
+	if len(lines) > 1 {
+		result += "\n" + strings.Join(lines[1:], "\n")
+	}
+
+	return result
+}


### PR DESCRIPTION
## Summary

This PR improves the error display in the TUI by using a fixed 2-line reserved space, preventing UI elements from bouncing when errors appear or disappear.

**Changes:**
- Added error formatting utility that limits errors to 2 lines with proper text wrapping and truncation
- Reserved 2 lines permanently for error display below the session list
- Added configurable `--error-clear-delay` flag (default: 10 seconds)
- Added hidden test commands for error display testing:
  - `alt+e`: Generate test error
  - `alt+shift+e`: Generate persistent Model-level test error

**Before:**
- Error display caused the list height to adjust dynamically
- Header and legend would bounce when errors appeared
- Layout was unstable during error lifecycle

**After:**
- Fixed 2-line error area is always reserved
- Header, list, and legend remain stable
- Smooth error appearance/disappearance without layout shifts

## Test plan

- [x] Build and test with `rocha-barcelona`
- [x] Verify error display with `alt+e` command
- [x] Verify 10-second auto-clear delay works correctly
- [x] Verify no UI bouncing when errors appear/disappear
- [x] Verify errors truncate to 2 lines with proper wrapping