### PR TITLE
feat: add session flag feature to mark important sessions

### DIFF
--- a/storage/schema.go
+++ b/storage/schema.go
@@ -23,3 +23,12 @@ type Session struct {
 	// Transient fields
 	GitStats interface{} `gorm:"-" json:"-"`
 }
+
+// SessionFlag represents a flag/marker for a session (extension table)
+type SessionFlag struct {
+	CreatedAt   time.Time
+	FlaggedAt   *time.Time `gorm:"default:null"`
+	IsFlagged   bool       `gorm:"not null;default:false"`
+	SessionName string     `gorm:"primaryKey"`
+	UpdatedAt   time.Time
+}

--- a/storage/types.go
+++ b/storage/types.go
@@ -10,15 +10,16 @@ type SessionState struct {
 
 // SessionInfo represents a session (compatible with old state package)
 type SessionInfo struct {
-	Name         string
-	ShellSession *SessionInfo
-	DisplayName  string
-	State        string
-	ExecutionID  string
-	LastUpdated  time.Time
-	RepoPath     string
-	RepoInfo     string
 	BranchName   string
-	WorktreePath string
+	DisplayName  string
+	ExecutionID  string
 	GitStats     interface{}
+	IsFlagged    bool
+	LastUpdated  time.Time
+	Name         string
+	RepoInfo     string
+	RepoPath     string
+	ShellSession *SessionInfo
+	State        string
+	WorktreePath string
 }


### PR DESCRIPTION
## Summary

Adds a session flag feature that allows users to mark important or active sessions with a visual indicator (⚑). The flag state is persisted in a SQLite database and survives app restarts.

## Changes

### Database Schema
- **New table**: `session_flags` with 1-to-1 relationship to `sessions`
- **Foreign key constraints**: CASCADE on update/delete to keep data consistent
- **Fields**: `session_name` (PK), `is_flagged`, `flagged_at`, timestamps

### Storage Layer
- Add `SessionFlag` model in `storage/schema.go`
- Add `IsFlagged` field to `SessionInfo` for in-memory representation
- Add `ToggleFlag()` method for atomic flag state updates
- Update `Load()` to fetch flags efficiently (single query for all flags)
- Add `UpdateSessionMetadata()` method for safe individual session updates
- Fix explicit table creation for `session_flags` (AutoMigrate has issues with SQLite foreign keys)

### UI Changes
- Add `IsFlagged` field to `SessionItem` struct
- Add flag indicator (⚑) in session list after session name
- Add 'f' keybinding to toggle flag state
- Update help text to show "f: flag"
- Both flag and shell indicators use default color for consistency

### Critical Bug Fix
- **Refactored `cmd/root.go`** to use individual `UpdateSessionMetadata()` calls instead of the dangerous full-state `Save()` method
- The old `Save()` method implemented a "full state replacement" pattern that **deleted all sessions not in memory**, causing catastrophic data loss when state loading failed
- New approach: individual updates never delete unrelated data

## UI Example

```
> 01. ● session-name ⚑ ⌨
     feat-branch | ↑2 ↓1 | +15 -3
```

Where:
- ⚑ = flagged session
- ⌨ = has shell session

## Test Plan

- [x] Build and install binary
- [x] Flag a session with 'f' key
- [x] Verify flag indicator appears
- [x] Restart app and verify flag persists
- [x] Toggle flag off with 'f' key
- [x] Verify database migration creates table correctly
- [x] Verify session deletion also removes flag (CASCADE)
- [x] Verify no data loss on app startup (critical bug fix)

## Technical Notes

### Why Individual Updates?

The previous code loaded the entire state into memory, modified it, and saved it back using `Save()`. This `Save()` method implemented a dangerous "delete everything not in this state" pattern:

```go
// OLD (DANGEROUS)
state := store.Load()           // Load everything
state.Sessions[x].Field = "y"   // Modify in memory  
store.Save(state)               // "Delete anything not in state!"
```

If `Load()` failed (e.g., missing table), `state.Sessions` would be empty, and `Save()` would delete all sessions from the database.

The fix uses targeted updates:

```go
// NEW (SAFE)
store.UpdateSessionMetadata(name, field1, field2, ...)  // Update only what changed
```

Individual updates can never accidentally delete unrelated data.

### Performance

- **Query count in Load()**: Adds 1 query for all flags (not N+1)
- **Flag toggle**: Single transaction, atomic update
- **Migration**: Runs once on first startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)