### PR TITLE
feat: auto-select newly added session

### DIFF
--- a/ui/model.go
+++ b/ui/model.go
@@ -337,6 +337,8 @@ func (m *Model) updateCreatingSession(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			// Refresh session list component
 			m.sessionList.RefreshFromState()
+			// Select the newly added session (always at position 0)
+			m.sessionList.list.Select(0)
 		}
 
 		return m, m.sessionList.Init()


### PR DESCRIPTION
## Summary
- Automatically selects newly created sessions in the UI
- Provides immediate visual feedback when a session is created
- Makes it easier to attach to the newly created session

## Implementation
Adds a single line in `ui/model.go` to select index 0 (where new sessions are positioned) after the session list is refreshed.

## Test plan
- [x] Build project successfully
- [ ] Create a new session and verify it becomes selected automatically
- [ ] Verify cursor is on the newly created session
- [ ] Verify you can immediately press enter to attach

## Changes
- Modified `ui/model.go` to call `list.Select(0)` after refreshing session list when a new session is created