### PR TITLE
feat: add consistent header with dev mode version info

### DIFF
--- a/.claude/rules/rocha_dev.md
+++ b/.claude/rules/rocha_dev.md
@@ -2,6 +2,15 @@
 
 When you finish:
 
-1. You need to build the binary for testing; after, copy it to ~/.local/bin; use unique name, based on the branch, like rocha-thisismybranchname-v1
+1. You need to build the binary for testing with build flags that inject meaningful version information:
+   - Use `-ldflags` to set version variables based on the branch name
+   - Version should include the branch name for easy identification (e.g., "fix-show-header-on-dialogs-v1")
+   - Set commit hash using `git rev-parse HEAD`
+   - Set build date using current timestamp
+   - Set go version using `go version`
+   - Example: `-ldflags="-X rocha/version.Version=branch-name-v1 -X rocha/version.Commit=$(git rev-parse HEAD) -X rocha/version.Date=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X rocha/version.GoVersion=$(go version | awk '{print $3}')"`
+   - After building, copy it to ~/.local/bin; use unique name, based on the branch, like rocha-thisismybranchname-v1
 
-2. Check if the ARCHITECTURE.md needs update, specially after adding new packages or components; don't forget, you should add or modify mostly diagrams; the amount of text in this file MUST be kept to a minimum.
+2. When running the built binary for testing, ALWAYS use the --dev flag to see version info in dialog headers and verify you're testing the correct binary.
+
+3. Check if the ARCHITECTURE.md needs update, specially after adding new packages or components; don't forget, you should add or modify mostly diagrams; the amount of text in this file MUST be kept to a minimum.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,6 +62,7 @@ func (c *CLI) AfterApply() error {
 
 // RunCmd starts the TUI application
 type RunCmd struct {
+	Dev             bool   `help:"Enable development mode (shows version info in dialogs)"`
 	Editor          string `help:"Editor to open sessions in (overrides $ROCHA_EDITOR, $VISUAL, $EDITOR)" default:"code"`
 	ErrorClearDelay int    `help:"Seconds before error messages auto-clear" default:"10"`
 	StatusColors    string `help:"Comma-separated ANSI color codes for statuses (e.g., '141,33,214,226,46')" default:"141,33,214,226,46"`
@@ -136,7 +137,7 @@ func (r *RunCmd) Run(tmuxClient tmux.Client, cli *CLI) error {
 	errorClearDelay := time.Duration(r.ErrorClearDelay) * time.Second
 	statusConfig := ui.NewStatusConfig(r.Statuses, r.StatusIcons, r.StatusColors)
 	p := tea.NewProgram(
-		ui.NewModel(tmuxClient, store, r.WorktreePath, r.Editor, errorClearDelay, statusConfig),
+		ui.NewModel(tmuxClient, store, r.WorktreePath, r.Editor, errorClearDelay, statusConfig, r.Dev),
 		tea.WithAltScreen(),       // Use alternate screen buffer
 		tea.WithMouseCellMotion(), // Enable mouse support
 	)

--- a/ui/dialog_header.go
+++ b/ui/dialog_header.go
@@ -1,0 +1,60 @@
+package ui
+
+import (
+	"fmt"
+	"rocha/version"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// renderHeader creates a consistent header used across the entire application.
+// It displays the app name with optional version info (in dev mode) and tagline.
+// If subtitle is provided, it's rendered below the tagline (used for dialog form titles).
+func renderHeader(devMode bool, subtitle string) string {
+	// Title style - matches session list (color 99, bold)
+	appNameStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("99"))
+
+	// Version info style - grey, shown next to title in dev mode
+	versionStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("240"))
+
+	// Tagline style - matches session list (color 250)
+	taglineStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("250"))
+
+	// Subtitle style - used for dialog form titles
+	subtitleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("86"))
+
+	// Build app name line (with optional version info)
+	appNameLine := appNameStyle.Render("Rocha")
+	if devMode {
+		versionInfo := fmt.Sprintf(" %s | %s | %s | %s",
+			version.Version,
+			version.Commit[:7], // Short commit hash
+			version.Date,
+			version.GoVersion)
+		appNameLine += versionStyle.Render(versionInfo)
+	}
+
+	// Build tagline
+	result := appNameLine + "\n"
+	result += taglineStyle.Render(version.Tagline)
+
+	// Add subtitle if provided (e.g., dialog form title)
+	if subtitle != "" {
+		result += "\n\n" + subtitleStyle.Render(subtitle)
+	}
+
+	result += "\n"
+	return result
+}
+
+// renderDialogHeader creates a header for dialogs with a form title.
+// This is a convenience wrapper around renderHeader for backward compatibility.
+func renderDialogHeader(devMode bool, formTitle string) string {
+	return renderHeader(devMode, formTitle)
+}

--- a/ui/session_form.go
+++ b/ui/session_form.go
@@ -35,33 +35,35 @@ type SessionFormResult struct {
 
 // SessionForm is a Bubble Tea component for creating sessions
 type SessionForm struct {
-	sessionManager tmux.SessionManager
-	store          *storage.Store
-	form           *huh.Form
-	worktreePath   string
-	sessionState   *storage.SessionState
-	result         SessionFormResult
 	Completed      bool // Exported so Model can check completion
 	cancelled      bool
 	creating       bool // True when session creation is in progress
+	devMode        bool
+	form           *huh.Form
+	result         SessionFormResult
+	sessionManager tmux.SessionManager
+	sessionState   *storage.SessionState
 	spinner        spinner.Model
+	store          *storage.Store
+	worktreePath   string
 }
 
 // NewSessionForm creates a new session creation form
-func NewSessionForm(sessionManager tmux.SessionManager, store *storage.Store, worktreePath string, sessionState *storage.SessionState) *SessionForm {
+func NewSessionForm(sessionManager tmux.SessionManager, store *storage.Store, worktreePath string, sessionState *storage.SessionState, devMode bool) *SessionForm {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
 
 	sf := &SessionForm{
-		sessionManager: sessionManager,
-		store:          store,
-		worktreePath:   worktreePath,
-		sessionState:   sessionState,
+		devMode:        devMode,
 		result: SessionFormResult{
 			CreateWorktree: true, // Default to true
 		},
-		spinner: s,
+		sessionManager: sessionManager,
+		sessionState:   sessionState,
+		spinner:        s,
+		store:          store,
+		worktreePath:   worktreePath,
 	}
 
 	// Check if we're in a git repository
@@ -192,10 +194,10 @@ func (sf *SessionForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (sf *SessionForm) View() string {
 	if sf.creating {
-		return fmt.Sprintf("\n%s Creating session...\n", sf.spinner.View())
+		return renderDialogHeader(sf.devMode, "Create Session") + fmt.Sprintf("\n%s Creating session...\n", sf.spinner.View())
 	}
 	if sf.form != nil {
-		return sf.form.View()
+		return renderDialogHeader(sf.devMode, "Create Session") + sf.form.View()
 	}
 	return ""
 }

--- a/ui/session_rename_form.go
+++ b/ui/session_rename_form.go
@@ -57,28 +57,30 @@ type SessionRenameFormResult struct {
 
 // SessionRenameForm is a Bubble Tea component for renaming sessions
 type SessionRenameForm struct {
-	sessionManager     tmux.SessionManager
-	store              *storage.Store
-	sessionState       *storage.SessionState
-	form               *huh.Form
-	oldTmuxName        string // Immutable - the session we're renaming
-	currentDisplayName string // Current display name for reference
-	result             SessionRenameFormResult
 	Completed          bool
 	cancelled          bool
+	currentDisplayName string // Current display name for reference
+	devMode            bool
+	form               *huh.Form
+	oldTmuxName        string // Immutable - the session we're renaming
+	result             SessionRenameFormResult
+	sessionManager     tmux.SessionManager
+	sessionState       *storage.SessionState
+	store              *storage.Store
 }
 
 // NewSessionRenameForm creates a new session rename form
-func NewSessionRenameForm(sessionManager tmux.SessionManager, store *storage.Store, sessionState *storage.SessionState, oldTmuxName, currentDisplayName string) *SessionRenameForm {
+func NewSessionRenameForm(sessionManager tmux.SessionManager, store *storage.Store, sessionState *storage.SessionState, oldTmuxName, currentDisplayName string, devMode bool) *SessionRenameForm {
 	sf := &SessionRenameForm{
-		sessionManager:     sessionManager,
-		store:              store,
-		sessionState:       sessionState,
-		oldTmuxName:        oldTmuxName,
 		currentDisplayName: currentDisplayName,
+		devMode:            devMode,
+		oldTmuxName:        oldTmuxName,
 		result: SessionRenameFormResult{
 			OldTmuxName: oldTmuxName,
 		},
+		sessionManager: sessionManager,
+		sessionState:   sessionState,
+		store:          store,
 	}
 
 	// Build form with single input field
@@ -143,7 +145,7 @@ func (sf *SessionRenameForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (sf *SessionRenameForm) View() string {
 	if sf.form != nil {
-		return sf.form.View()
+		return renderDialogHeader(sf.devMode, "Rename Session") + sf.form.View()
 	}
 	return ""
 }

--- a/ui/session_status_form.go
+++ b/ui/session_status_form.go
@@ -22,6 +22,7 @@ type SessionStatusFormResult struct {
 type SessionStatusForm struct {
 	Completed    bool
 	cancelled    bool
+	devMode      bool
 	form         *huh.Form
 	result       SessionStatusFormResult
 	selectedItem string // Holds the selected option (status name or "<clear>")
@@ -31,14 +32,15 @@ type SessionStatusForm struct {
 }
 
 // NewSessionStatusForm creates a new session status form
-func NewSessionStatusForm(store *storage.Store, sessionName string, currentStatus *string, statusConfig *StatusConfig) *SessionStatusForm {
+func NewSessionStatusForm(store *storage.Store, sessionName string, currentStatus *string, statusConfig *StatusConfig, devMode bool) *SessionStatusForm {
 	sf := &SessionStatusForm{
-		sessionName:  sessionName,
-		statusConfig: statusConfig,
-		store:        store,
+		devMode:      devMode,
 		result: SessionStatusFormResult{
 			SessionName: sessionName,
 		},
+		sessionName:  sessionName,
+		statusConfig: statusConfig,
+		store:        store,
 	}
 
 	// Build status options
@@ -110,7 +112,7 @@ func (sf *SessionStatusForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (sf *SessionStatusForm) View() string {
 	if sf.form != nil {
-		return sf.form.View()
+		return renderDialogHeader(sf.devMode, "Set Status") + sf.form.View()
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary

This PR adds a consistent header component across all UI screens and introduces a `--dev` flag that displays version information for easier testing and debugging.

## Changes

### Core Features
- **--dev flag**: New flag on the `run` command to enable development mode
- **Reusable header component**: Created `renderHeader()` function in `ui/dialog_header.go` for consistent styling
- **Version info display**: When `--dev` is enabled, shows version, commit hash, date, and Go version in grey next to the title

### UI Updates
- **Main screen**: Uses consistent header with optional version info
- **Create Session dialog**: Includes header with "Create Session" subtitle
- **Rename Session dialog**: Includes header with "Rename Session" subtitle  
- **Set Status dialog**: Includes header with "Set Status" subtitle
- **Remove Worktree dialog**: Includes header with "Remove Worktree" subtitle

### Developer Experience
- Updated `.claude/rules/rocha_dev.md` with instructions for:
  - Building with meaningful version info using ldflags
  - Including branch name in version for easy identification
  - Always using `--dev` flag when testing

## Usage

Build with version info:
```bash
go build -ldflags="-X rocha/version.Version=branch-name-v1 \
  -X rocha/version.Commit=$(git rev-parse HEAD) \
  -X rocha/version.Date=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
  -X rocha/version.GoVersion=$(go version | awk '{print $3}')"
```

Run with dev mode:
```bash
rocha run --dev
```

## Technical Details

- All form components now accept a `devMode` parameter
- Header styling matches existing session list (color 99 for title, color 250 for tagline)
- Version info is displayed in color 240 (grey) next to the title
- Maintains backward compatibility with existing code

## Testing

Tested with:
- Creating new sessions
- Renaming sessions
- Setting status
- Removing worktrees
- Version info display in dev mode