### PR TITLE
fix: allow terminal text selection by removing mouse capture

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,8 +138,7 @@ func (r *RunCmd) Run(tmuxClient tmux.Client, cli *CLI) error {
 	statusConfig := ui.NewStatusConfig(r.Statuses, r.StatusIcons, r.StatusColors)
 	p := tea.NewProgram(
 		ui.NewModel(tmuxClient, store, r.WorktreePath, r.Editor, errorClearDelay, statusConfig, r.Dev),
-		tea.WithAltScreen(),       // Use alternate screen buffer
-		tea.WithMouseCellMotion(), // Enable mouse support
+		tea.WithAltScreen(), // Use alternate screen buffer
 	)
 
 	logging.Logger.Info("Starting TUI program")


### PR DESCRIPTION
## Summary
- Removes `tea.WithMouseCellMotion()` from Bubble Tea program initialization to restore normal terminal text selection behavior
- Mouse capture was preventing users from highlighting and copying text from the TUI

## Changes
- Modified `cmd/root.go` to remove the mouse capture option
- All keyboard navigation functionality remains intact

## Impact
- ✅ Users can now select and copy text from the terminal using standard mouse selection
- ✅ All keyboard shortcuts continue to work (j/k, arrow keys, r, f, x, o, s, n, etc.)
- ❌ Mouse click interactions are disabled (not implemented anyway)

## Test plan
- [x] Build and install binary: `go build -o ~/.local/bin/rocha-fix-mouse-v1 .`
- [ ] Run application and verify text selection works with mouse
- [ ] Verify all keyboard navigation still functions correctly
- [ ] Test copy/paste functionality