### PR TITLE
fix: hide status command from help output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ type CLI struct {
 
 	Run         RunCmd         `cmd:"" help:"Start the rocha TUI (default)" default:"1"`
 	Setup       SetupCmd       `cmd:"setup" help:"Configure tmux status bar integration automatically"`
-	Status      StatusCmd      `cmd:"status" help:"Show session state counts for tmux status bar"`
+	Status      StatusCmd      `cmd:"status" help:"Show session state counts for tmux status bar" hidden:""`
 	Attach      AttachCmd      `cmd:"attach" help:"Attach to tmux session (creates if needed)"`
 	StartClaude StartClaudeCmd `cmd:"start-claude" help:"Start Claude Code with hooks configured" hidden:""`
 	PlaySound   PlaySoundCmd   `cmd:"play-sound" help:"Play notification sound (cross-platform)" hidden:""`


### PR DESCRIPTION
## Summary

- Hide the `status` command from CLI help output by adding the `hidden:""` Kong tag
- The command remains fully functional for tmux status bar integration
- Follows the pattern of other internal commands (`start-claude`, `play-sound`, `notify`)

## Test plan

- [ ] Build and verify `status` command is hidden from `rocha --help`
- [ ] Verify `rocha status` still executes correctly
- [ ] Confirm tmux status bar integration continues to work