### PR TITLE
refactor: introduce Dialog wrapper for automatic header rendering

### DIFF
--- a/ui/dialog.go
+++ b/ui/dialog.go
@@ -1,0 +1,67 @@
+package ui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// Dialog wraps any tea.Model content and automatically adds a header with title.
+// This enforces consistent dialog headers across the application "by design" -
+// you cannot create a dialog without getting a header.
+//
+// Usage:
+//   contentForm := NewSessionForm(...)
+//   dialog := NewDialog("Create Session", contentForm, devMode)
+//   dialog.Init()  // Delegates to contentForm.Init()
+//   dialog.Update(msg)  // Delegates to contentForm.Update(msg)
+//   dialog.View()  // Returns header + contentForm.View()
+//
+// Design principles:
+// - Composition: Dialog wraps content via delegation (not inheritance)
+// - Small interfaces: Uses existing tea.Model interface (Init, Update, View)
+// - Open/Closed: Add new dialogs by wrapping content, no Dialog changes needed
+// - Single responsibility: Dialog handles structure, content handles business logic
+type Dialog struct {
+	content tea.Model
+	devMode bool
+	title   string
+}
+
+// NewDialog creates a new dialog wrapper that automatically adds headers.
+// The wrapped content will have renderDialogHeader() automatically prepended to its View().
+func NewDialog(title string, content tea.Model, devMode bool) *Dialog {
+	return &Dialog{
+		content: content,
+		devMode: devMode,
+		title:   title,
+	}
+}
+
+// Init delegates to wrapped content's Init method.
+func (d *Dialog) Init() tea.Cmd {
+	return d.content.Init()
+}
+
+// Update delegates to wrapped content's Update method.
+// The returned tea.Model is the Dialog itself with updated content.
+func (d *Dialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	updatedContent, cmd := d.content.Update(msg)
+	d.content = updatedContent
+	return d, cmd
+}
+
+// View automatically prepends the dialog header to the wrapped content's view.
+// This ensures all dialogs have consistent headers without manual calls to renderDialogHeader().
+func (d *Dialog) View() string {
+	return renderDialogHeader(d.devMode, d.title) + d.content.View()
+}
+
+// Content returns the wrapped content for type assertion.
+// This allows callers to access content-specific fields after Update().
+//
+// Example:
+//   if content, ok := dialog.Content().(*SessionForm); ok {
+//       if content.Completed {
+//           result := content.Result()
+//       }
+//   }
+func (d *Dialog) Content() tea.Model {
+	return d.content
+}

--- a/ui/dialog_header.go
+++ b/ui/dialog_header.go
@@ -55,6 +55,11 @@ func renderHeader(devMode bool, subtitle string) string {
 
 // renderDialogHeader creates a header for dialogs with a form title.
 // This is a convenience wrapper around renderHeader for backward compatibility.
+//
+// NOTE: This function should ONLY be called by the Dialog wrapper in dialog.go.
+// Do not call this function directly from form components. Instead, wrap your
+// form component in a Dialog using NewDialog(), which will automatically add
+// the header. This enforces consistent headers "by design" across all dialogs.
 func renderDialogHeader(devMode bool, formTitle string) string {
 	return renderHeader(devMode, formTitle)
 }

--- a/ui/session_comment_form.go
+++ b/ui/session_comment_form.go
@@ -25,7 +25,6 @@ type SessionCommentForm struct {
 	Completed      bool
 	cancelled      bool
 	currentComment string
-	devMode        bool
 	form           *huh.Form
 	result         SessionCommentFormResult
 	sessionName    string
@@ -33,10 +32,9 @@ type SessionCommentForm struct {
 }
 
 // NewSessionCommentForm creates a new session comment form
-func NewSessionCommentForm(store *storage.Store, sessionName, currentComment string, devMode bool) *SessionCommentForm {
+func NewSessionCommentForm(store *storage.Store, sessionName, currentComment string) *SessionCommentForm {
 	sf := &SessionCommentForm{
 		currentComment: currentComment,
-		devMode:        devMode,
 		sessionName:    sessionName,
 		store:          store,
 		result: SessionCommentFormResult{
@@ -96,7 +94,7 @@ func (sf *SessionCommentForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (sf *SessionCommentForm) View() string {
 	if sf.form != nil {
-		return renderDialogHeader(sf.devMode, "Edit Session Comment") + sf.form.View()
+		return sf.form.View()
 	}
 	return ""
 }

--- a/ui/session_form.go
+++ b/ui/session_form.go
@@ -38,7 +38,6 @@ type SessionForm struct {
 	Completed      bool // Exported so Model can check completion
 	cancelled      bool
 	creating       bool // True when session creation is in progress
-	devMode        bool
 	form           *huh.Form
 	result         SessionFormResult
 	sessionManager tmux.SessionManager
@@ -49,13 +48,12 @@ type SessionForm struct {
 }
 
 // NewSessionForm creates a new session creation form
-func NewSessionForm(sessionManager tmux.SessionManager, store *storage.Store, worktreePath string, sessionState *storage.SessionState, devMode bool) *SessionForm {
+func NewSessionForm(sessionManager tmux.SessionManager, store *storage.Store, worktreePath string, sessionState *storage.SessionState) *SessionForm {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
 
 	sf := &SessionForm{
-		devMode:        devMode,
 		result: SessionFormResult{
 			CreateWorktree: true, // Default to true
 		},
@@ -194,10 +192,10 @@ func (sf *SessionForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (sf *SessionForm) View() string {
 	if sf.creating {
-		return renderDialogHeader(sf.devMode, "Create Session") + fmt.Sprintf("\n%s Creating session...\n", sf.spinner.View())
+		return fmt.Sprintf("\n%s Creating session...\n", sf.spinner.View())
 	}
 	if sf.form != nil {
-		return renderDialogHeader(sf.devMode, "Create Session") + sf.form.View()
+		return sf.form.View()
 	}
 	return ""
 }

--- a/ui/session_rename_form.go
+++ b/ui/session_rename_form.go
@@ -60,7 +60,6 @@ type SessionRenameForm struct {
 	Completed          bool
 	cancelled          bool
 	currentDisplayName string // Current display name for reference
-	devMode            bool
 	form               *huh.Form
 	oldTmuxName        string // Immutable - the session we're renaming
 	result             SessionRenameFormResult
@@ -70,10 +69,9 @@ type SessionRenameForm struct {
 }
 
 // NewSessionRenameForm creates a new session rename form
-func NewSessionRenameForm(sessionManager tmux.SessionManager, store *storage.Store, sessionState *storage.SessionState, oldTmuxName, currentDisplayName string, devMode bool) *SessionRenameForm {
+func NewSessionRenameForm(sessionManager tmux.SessionManager, store *storage.Store, sessionState *storage.SessionState, oldTmuxName, currentDisplayName string) *SessionRenameForm {
 	sf := &SessionRenameForm{
 		currentDisplayName: currentDisplayName,
-		devMode:            devMode,
 		oldTmuxName:        oldTmuxName,
 		result: SessionRenameFormResult{
 			OldTmuxName: oldTmuxName,
@@ -145,7 +143,7 @@ func (sf *SessionRenameForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (sf *SessionRenameForm) View() string {
 	if sf.form != nil {
-		return renderDialogHeader(sf.devMode, "Rename Session") + sf.form.View()
+		return sf.form.View()
 	}
 	return ""
 }

--- a/ui/session_status_form.go
+++ b/ui/session_status_form.go
@@ -22,7 +22,6 @@ type SessionStatusFormResult struct {
 type SessionStatusForm struct {
 	Completed    bool
 	cancelled    bool
-	devMode      bool
 	form         *huh.Form
 	result       SessionStatusFormResult
 	selectedItem string // Holds the selected option (status name or "<clear>")
@@ -32,9 +31,8 @@ type SessionStatusForm struct {
 }
 
 // NewSessionStatusForm creates a new session status form
-func NewSessionStatusForm(store *storage.Store, sessionName string, currentStatus *string, statusConfig *StatusConfig, devMode bool) *SessionStatusForm {
+func NewSessionStatusForm(store *storage.Store, sessionName string, currentStatus *string, statusConfig *StatusConfig) *SessionStatusForm {
 	sf := &SessionStatusForm{
-		devMode:      devMode,
 		result: SessionStatusFormResult{
 			SessionName: sessionName,
 		},
@@ -112,7 +110,7 @@ func (sf *SessionStatusForm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (sf *SessionStatusForm) View() string {
 	if sf.form != nil {
-		return renderDialogHeader(sf.devMode, "Set Status") + sf.form.View()
+		return sf.form.View()
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary
- Implements a generic Dialog wrapper that automatically adds headers to all dialog forms
- Eliminates manual renderDialogHeader() calls across the codebase
- Enforces consistent headers "by design" - impossible to forget adding headers

## Changes

### New Component
- **ui/dialog.go**: Generic Dialog wrapper implementing tea.Model interface
  - Automatically prepends headers in View() method
  - Delegates Init() and Update() to wrapped content
  - Provides Content() accessor for type assertions

### Simplified Forms
All form components now focus solely on business logic:
- **ui/session_form.go**: Removed devMode field, simplified View()
- **ui/session_rename_form.go**: Removed devMode field, simplified View()
- **ui/session_status_form.go**: Removed devMode field, simplified View()
- **ui/session_comment_form.go**: Removed devMode field, simplified View()

### Model Integration
- **ui/model.go**: Updated to wrap all forms in Dialog for automatic headers
  - Changed struct fields to use *Dialog instead of form types
  - Updated all dialog creation to use NewDialog()
  - Modified Update() methods to access wrapped content
  - Simplified View() - dialogs handle headers automatically

### Documentation
- **ui/dialog_header.go**: Added note that renderDialogHeader() should only be called by Dialog wrapper

## Benefits
- **DRY**: Eliminates 5 duplicate renderDialogHeader() calls
- **Maintainability**: Impossible to forget adding headers to new dialogs
- **Separation of concerns**: Forms handle logic, Dialog handles structure
- **Open/Closed principle**: New dialogs added by composition, no wrapper changes needed

## Testing
Built and tested with:
```bash
go build -ldflags="-X rocha/version.Version=refactor-generic-way-to-start-a-dialog-v1 ..." -o rocha-refactor-dialog-v1
rocha-refactor-dialog-v1 --dev
```

Verified all dialogs display headers correctly:
- Create session dialog
- Rename session dialog
- Set status dialog
- Edit comment dialog
- Remove worktree dialog