### PR TITLE
feat: add settings file support for persistent configuration

### DIFF
--- a/config/settings.go
+++ b/config/settings.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Settings represents the structure of ~/.rocha/settings.json
+type Settings struct {
+	DBPath          string      `json:"db_path,omitempty"`
+	Debug           *bool       `json:"debug,omitempty"`
+	Editor          string      `json:"editor,omitempty"`
+	ErrorClearDelay *int        `json:"error_clear_delay,omitempty"`
+	MaxLogFiles     *int        `json:"max_log_files,omitempty"`
+	StatusColors    StringArray `json:"status_colors,omitempty"`
+	Statuses        StringArray `json:"statuses,omitempty"`
+	WorktreePath    string      `json:"worktree_path,omitempty"`
+}
+
+// StringArray supports both JSON arrays and comma-separated strings
+type StringArray []string
+
+// UnmarshalJSON implements custom unmarshaling for StringArray
+func (sa *StringArray) UnmarshalJSON(data []byte) error {
+	// Try array format first
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err == nil {
+		*sa = arr
+		return nil
+	}
+
+	// Fall back to comma-separated string
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+	*sa = parseCommaSeparated(str)
+	return nil
+}
+
+// parseCommaSeparated splits comma-separated string and trims whitespace
+func parseCommaSeparated(s string) []string {
+	if s == "" {
+		return []string{}
+	}
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+// LoadSettings loads settings from ~/.rocha/settings.json
+// Returns empty Settings if file doesn't exist (not an error)
+func LoadSettings() (*Settings, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	path := filepath.Join(homeDir, ".rocha", "settings.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Settings{}, nil // Not an error, use defaults
+		}
+		return nil, fmt.Errorf("failed to read settings file: %w", err)
+	}
+
+	var settings Settings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return nil, fmt.Errorf("invalid settings.json: %w", err)
+	}
+
+	// Expand paths that start with ~
+	if settings.DBPath != "" {
+		settings.DBPath = expandPath(settings.DBPath)
+	}
+	if settings.WorktreePath != "" {
+		settings.WorktreePath = expandPath(settings.WorktreePath)
+	}
+
+	return &settings, nil
+}
+
+// expandPath expands ~ to home directory in paths
+func expandPath(path string) string {
+	if len(path) > 0 && path[0] == '~' {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return path // Return as-is if we can't get home dir
+		}
+		if len(path) == 1 {
+			return homeDir
+		}
+		return filepath.Join(homeDir, path[1:])
+	}
+	return path
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"rocha/cmd"
+	"rocha/config"
 	"rocha/tmux"
 	"rocha/version"
 
@@ -11,11 +12,19 @@ import (
 )
 
 func main() {
+	// Load settings from ~/.rocha/settings.json
+	settings, err := config.LoadSettings()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to load settings: %v\n", err)
+		settings = &config.Settings{} // Use empty settings
+	}
+
 	// Create tmux client for dependency injection
 	tmuxClient := tmux.NewClient()
 
 	// Parse CLI arguments with Kong
 	var cli cmd.CLI
+	cli.SetSettings(settings) // Set settings before parsing
 	ctx := kong.Parse(&cli,
 		kong.Name("rocha"),
 		kong.Description(version.Tagline),


### PR DESCRIPTION
## Summary

- Add support for persistent configuration via `~/.rocha/settings.json`
- Allows users to customize rocha preferences without passing CLI flags every time
- Implements proper precedence: CLI flags > environment variables > settings.json > defaults

## Features

### Supported Settings

All settings are optional in the JSON file:

| Setting | Type | Default | Description |
|---------|------|---------|-------------|
| `editor` | string | "code" | Editor to open sessions in |
| `statuses` | array/string | ["spec","plan","implement","review","done"] | Status workflow names |
| `status_colors` | array/string | ["141","33","214","226","46"] | ANSI color codes for statuses |
| `worktree_path` | string | "~/.rocha/worktrees" | Base directory for git worktrees |
| `error_clear_delay` | int | 10 | Seconds before error messages auto-clear |
| `db_path` | string | "~/.rocha/state.db" | Path to SQLite database |
| `max_log_files` | int | 1000 | Maximum number of log files to keep |
| `debug` | bool | false | Enable debug logging |

### Flexible Array Format

Array fields support both JSON arrays and comma-separated strings:
```json
"statuses": ["todo", "doing", "done"]
```
or
```json
"statuses": "todo,doing,done"
```

### Path Expansion

Tilde (~) expansion works in path settings:
```json
"worktree_path": "~/my-worktrees"
```

### Graceful Degradation

- Missing settings.json is not an error (uses defaults)
- Invalid JSON shows warning but continues with defaults
- All settings are optional

## Implementation Details

- New `config` package with `Settings` struct and `LoadSettings()` function
- Settings loaded before CLI parsing in `main.go`
- Applied in `AfterApply()` hook and command `Run()` methods with proper precedence checking
- Uses `strings.Join()` from stdlib for array-to-string conversion

## Test Plan

- [x] Create `~/.rocha/settings.json` with custom editor and verify it's used
- [x] Override settings.json value with CLI flag and verify flag wins
- [x] Remove settings.json and verify defaults work
- [x] Test with invalid JSON and verify warning is shown but app continues
- [x] Test array format with both JSON arrays and comma-separated strings
- [x] Test path expansion with tilde in worktree_path
- [x] Verify debug mode can be enabled via settings.json

## Example settings.json

```json
{
  "editor": "vim",
  "statuses": ["todo", "doing", "done"],
  "status_colors": ["red", "yellow", "green"],
  "worktree_path": "~/.rocha/worktrees",
  "error_clear_delay": 10,
  "db_path": "~/.rocha/state.db",
  "max_log_files": 1000,
  "debug": false
}
```