### PR TITLE
docs: add missing shortcuts and improve help text clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ For all available commands and options, run `rocha --help`.
 - `alt+1` to `alt+7` - Quick attach to sessions by number
 - `alt+enter` - Open shell session (⌨) for the selected session
 - `r` - Rename session
+- `c` - Add/edit comment on session
+- `f` - Toggle flag (mark session as important)
+- `s` - Cycle through statuses quickly (working → idle → waiting → exited)
+- `shift+s` - Set status (interactive form to choose status)
 - `o` - Open session in your editor
 - `x` - Kill session
 - `↑/↓` or `j/k` - Navigate

--- a/ui/session_list.go
+++ b/ui/session_list.go
@@ -397,15 +397,16 @@ func (sl *SessionList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "s":
+			// s: Cycle through statuses (default/quick action)
 			if item, ok := sl.list.SelectedItem().(SessionItem); ok {
-				sl.SessionToSetStatus = item.Session
-				return sl, nil
+				return sl, sl.cycleSessionStatus(item.Session.Name)
 			}
 
 		case "S":
-			// Shift+S: Cycle through statuses
+			// Shift+S: Open status form (edit action)
 			if item, ok := sl.list.SelectedItem().(SessionItem); ok {
-				return sl, sl.cycleSessionStatus(item.Session.Name)
+				sl.SessionToSetStatus = item.Session
+				return sl, nil
 			}
 
 		case "K": // Shift+K (uppercase K)
@@ -506,8 +507,9 @@ func (sl *SessionList) View() string {
 	// Add custom help (status legend first, then keys)
 	s += "\n\n"
 	helpText := sl.renderStatusLegend() + "\n\n"
-	helpText += "↑/k: up • ↓/j: down • shift+↑/k: move up • shift+↓/j: move down • /: filter • n: new • r: rename • c: comment • f: flag • x: kill\n"
-	helpText += "enter/alt+1-7: attach • ctrl+q: detach • alt+enter: shell (⌨) • o: open editor • q: quit"
+	helpText += "↑/k: up • ↓/j: down • shift+↑/k: move up • shift+↓/j: move down • /: filter\n"
+	helpText += "n: new • r: rename • c: comment (⌨) • f: flag (⚑) • s: cycle status • shift+s: set status • x: kill\n"
+	helpText += "enter/alt+1-7: open • alt+enter: shell (>_) • o: editor • ctrl+q: to list • q: quit"
 
 	s += helpStyle.Render(helpText)
 


### PR DESCRIPTION
## Summary

- Document missing keyboard shortcuts in README (comment, flag, status operations)
- Swap `s` and `shift+s` behavior: `s` now cycles status (quick action), `shift+s` opens form (edit action)
- Reorganize in-app help text into 3 logical lines for better readability
- Update terminology: "open" instead of "attach", "to list" instead of "detach"
- Add visual icons to help text: comment (⌨), flag (⚑), and shell (>_)

## Test plan

- [ ] Build and run the binary with `--dev` flag
- [ ] Verify in-app help text displays all shortcuts on 3 lines
- [ ] Test `s` key cycles through statuses (working → idle → waiting → exited)
- [ ] Test `shift+s` opens the status form
- [ ] Test `c` opens comment form
- [ ] Test `f` toggles flag
- [ ] Verify README.md shows all documented shortcuts
- [ ] Confirm help text fits within terminal without wrapping