### PR TITLE
fix: transition to working state after answering AskUserQuestion

### DIFF
--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -16,7 +16,7 @@ import (
 // NotifyCmd handles notification events from Claude hooks
 type NotifyCmd struct {
 	SessionName string `arg:"" help:"Name of the session triggering the notification"`
-	EventType   string `arg:"" help:"Type of event: stop, prompt, start" default:"stop"`
+	EventType   string `arg:"" help:"Type of event: stop, prompt, working, start, notification, end" default:"stop"`
 	ExecutionID string `help:"Execution ID from parent rocha TUI" optional:""`
 }
 
@@ -89,6 +89,8 @@ func (n *NotifyCmd) Run(cli *CLI) error {
 		sessionState = state.StateIdle // Session started and ready for input
 	case "prompt":
 		sessionState = state.StateWorking // User submitted prompt
+	case "working":
+		sessionState = state.StateWorking // Claude is actively working (after answering question)
 	case "end":
 		sessionState = state.StateExited // Claude has exited
 	default:

--- a/cmd/start_claude.go
+++ b/cmd/start_claude.go
@@ -129,6 +129,18 @@ func (s *StartClaudeCmd) Run(cli *CLI) error {
 					},
 				},
 			},
+			// PostToolUse: When AskUserQuestion tool completes (user has answered)
+			"PostToolUse": []map[string]interface{}{
+				{
+					"matcher": "AskUserQuestion",
+					"hooks": []map[string]interface{}{
+						{
+							"type":    "command",
+							"command": fmt.Sprintf("%s notify %s working --execution-id=%s", rochaBin, sessionName, executionID),
+						},
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes the issue where session state remained stuck as "waiting" (red ◐) after users answered AskUserQuestion dialogs, instead of transitioning back to "working" (green ●).

## Changes

- **cmd/start_claude.go**: Added PostToolUse hook that triggers when AskUserQuestion tool completes, sending a "working" event
- **cmd/notify.go**: Added "working" event case that maps to StateWorking state
- **cmd/notify.go**: Updated EventType help text to include all valid event types

## Root Cause

When users answer AskUserQuestion dialogs, Claude Code treats it as providing input to an already-executing tool call. No UserPromptSubmit hook fires, leaving the session state stuck as "waiting" even though Claude is actively processing.

## Solution

The PostToolUse hook now detects when AskUserQuestion completes and immediately transitions the state back to "working", providing accurate visual feedback to users.

## Test Plan

- [ ] Build and run the updated binary with `--dev` flag
- [ ] Create a Claude session and trigger AskUserQuestion
- [ ] Verify state transitions: working → waiting (when question shown) → working (after answering)
- [ ] Check hook logs at ~/.local/state/rocha/ for working event entries
- [ ] Test multiple questions in sequence