### PR TITLE
docs: add debug flags usage to development guidelines

### DIFF
--- a/.claude/rules/rocha_dev.md
+++ b/.claude/rules/rocha_dev.md
@@ -1,6 +1,14 @@
 # Things to do/know during rocha dev
 
-When you finish:
+## Running with Debug Flags
+
+To run rocha with debug output:
+
+```bash
+rocha --debug --debug-file <file name>
+```
+
+## When you finish:
 
 1. You need to build the binary for testing with build flags that inject meaningful version information:
    - Use `-ldflags` to set version variables based on the branch name


### PR DESCRIPTION
## Summary
- Added instructions for running rocha with debug flags (`--debug` and `--debug-file`) to the development guidelines

## Test plan
- Review the updated documentation in `.claude/rules/rocha_dev.md`
- Verify the debug flags usage is clear and accurate