### PR TITLE
feat: display relative timestamps for last state changes

### DIFF
--- a/ui/model.go
+++ b/ui/model.go
@@ -80,13 +80,14 @@ type Model struct {
 	state               uiState
 	statusConfig        *StatusConfig  // Status configuration for implementation statuses
 	store               *storage.Store // Storage for persistent state
+	timestampConfig     *TimestampColorConfig // Timestamp color configuration
 	tmuxClient          tmux.Client
 	width               int
 	worktreeRemovalForm *Dialog        // Worktree removal dialog
 	worktreePath        string
 }
 
-func NewModel(tmuxClient tmux.Client, store *storage.Store, worktreePath string, editor string, errorClearDelay time.Duration, statusConfig *StatusConfig, devMode bool) *Model {
+func NewModel(tmuxClient tmux.Client, store *storage.Store, worktreePath string, editor string, errorClearDelay time.Duration, statusConfig *StatusConfig, timestampConfig *TimestampColorConfig, devMode bool) *Model {
 	// Load session state - this is the source of truth
 	sessionState, stateErr := store.Load(context.Background())
 	var errMsg error
@@ -97,7 +98,7 @@ func NewModel(tmuxClient tmux.Client, store *storage.Store, worktreePath string,
 	}
 
 	// Create session list component
-	sessionList := NewSessionList(tmuxClient, store, editor, statusConfig, devMode)
+	sessionList := NewSessionList(tmuxClient, store, editor, statusConfig, timestampConfig, devMode)
 
 	return &Model{
 		devMode:         devMode,
@@ -109,6 +110,7 @@ func NewModel(tmuxClient tmux.Client, store *storage.Store, worktreePath string,
 		state:           stateList,
 		statusConfig:    statusConfig,
 		store:           store,
+		timestampConfig: timestampConfig,
 		tmuxClient:      tmuxClient,
 		worktreePath:    worktreePath,
 	}

--- a/ui/time_format.go
+++ b/ui/time_format.go
@@ -1,0 +1,86 @@
+package ui
+
+import (
+	"fmt"
+	"time"
+)
+
+// formatRelativeTime converts a timestamp to a human-readable relative time string.
+// Returns empty string for zero times.
+//
+// Format:
+//   - < 1 min: "just now"
+//   - < 1 hour: "Xm ago"
+//   - < 24 hours: "Xh ago"
+//   - < 7 days: "Xd ago"
+//   - < 30 days: "Xw ago"
+//   - < 365 days: "Xmo ago"
+//   - >= 365 days: "Xy ago"
+func formatRelativeTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+
+	elapsed := time.Since(t)
+
+	// Less than 1 minute
+	if elapsed < time.Minute {
+		return "just now"
+	}
+
+	// Less than 1 hour
+	if elapsed < time.Hour {
+		minutes := int(elapsed.Minutes())
+		return formatWithUnit(minutes, "m")
+	}
+
+	// Less than 24 hours
+	if elapsed < 24*time.Hour {
+		hours := int(elapsed.Hours())
+		return formatWithUnit(hours, "h")
+	}
+
+	// Less than 7 days
+	if elapsed < 7*24*time.Hour {
+		days := int(elapsed.Hours() / 24)
+		return formatWithUnit(days, "d")
+	}
+
+	// Less than 30 days
+	if elapsed < 30*24*time.Hour {
+		weeks := int(elapsed.Hours() / (24 * 7))
+		return formatWithUnit(weeks, "w")
+	}
+
+	// Less than 365 days
+	if elapsed < 365*24*time.Hour {
+		months := int(elapsed.Hours() / (24 * 30))
+		return formatWithUnit(months, "mo")
+	}
+
+	// 365 days or more
+	years := int(elapsed.Hours() / (24 * 365))
+	return formatWithUnit(years, "y")
+}
+
+// formatWithUnit creates a formatted string with value and unit followed by "ago"
+func formatWithUnit(value int, unit string) string {
+	return fmt.Sprintf("%d%s ago", value, unit)
+}
+
+// getTimestampColor determines the color code based on how long ago the timestamp was.
+// Recent updates use one color, older updates use warning color, very old use stale color.
+func getTimestampColor(t time.Time, config *TimestampColorConfig) string {
+	if t.IsZero() {
+		return config.RecentColor
+	}
+
+	elapsed := time.Since(t).Minutes()
+
+	if elapsed < float64(config.RecentMinutes) {
+		return config.RecentColor
+	} else if elapsed < float64(config.WarningMinutes) {
+		return config.WarningColor
+	}
+	return config.StaleColor
+}

--- a/ui/timestamp_config.go
+++ b/ui/timestamp_config.go
@@ -1,0 +1,47 @@
+package ui
+
+// TimestampColorConfig holds configuration for timestamp display colors.
+// Colors change based on how recently the session state was updated.
+type TimestampColorConfig struct {
+	RecentColor    string // Color for recent updates (< RecentMinutes)
+	RecentMinutes  int    // Threshold in minutes for recent color
+	StaleColor     string // Color for very old updates (>= WarningMinutes)
+	WarningColor   string // Color for moderately old updates (>= RecentMinutes, < WarningMinutes)
+	WarningMinutes int    // Threshold in minutes for warning color
+}
+
+// NewTimestampColorConfig creates a new TimestampColorConfig with the provided values.
+// If values are zero/empty, defaults are applied:
+//   - RecentMinutes: 5
+//   - WarningMinutes: 20
+//   - RecentColor: "241" (gray)
+//   - WarningColor: "136" (amber/yellow)
+//   - StaleColor: "208" (orange)
+func NewTimestampColorConfig(recentMin, warningMin int, recentColor, warningColor, staleColor string) *TimestampColorConfig {
+	config := &TimestampColorConfig{
+		RecentMinutes:  recentMin,
+		WarningMinutes: warningMin,
+		RecentColor:    recentColor,
+		WarningColor:   warningColor,
+		StaleColor:     staleColor,
+	}
+
+	// Apply defaults if not set
+	if config.RecentMinutes == 0 {
+		config.RecentMinutes = 5
+	}
+	if config.WarningMinutes == 0 {
+		config.WarningMinutes = 20
+	}
+	if config.RecentColor == "" {
+		config.RecentColor = "241"
+	}
+	if config.WarningColor == "" {
+		config.WarningColor = "136"
+	}
+	if config.StaleColor == "" {
+		config.StaleColor = "208"
+	}
+
+	return config
+}


### PR DESCRIPTION
## Summary
- Add human-readable relative time display showing when each session's state was last updated
- Timestamps appear at the end of each session line with dynamic color coding based on age
- Configurable thresholds and colors via CLI flags

## Features
- Relative time formatting (e.g., "5m ago", "2h ago", "3d ago")
- Color-coded timestamps: gray (recent < 5 min), amber (warning < 20 min), orange (stale ≥ 20 min)
- Configurable via new CLI flags:
  - `--timestamp-recent-minutes` (default: 5)
  - `--timestamp-warning-minutes` (default: 20)
  - `--timestamp-recent-color` (default: "241")
  - `--timestamp-warning-color` (default: "136")
  - `--timestamp-stale-color` (default: "208")

## Implementation
- Created time formatting utility (ui/time_format.go)
- Added timestamp configuration system (ui/timestamp_config.go)
- Extended SessionItem with LastUpdated field
- Added UpdateExecutionID() storage method to preserve timestamps during app startup
- Integrated timestamp display in session list rendering

## Display Format
Sessions now show timestamps like:
\`\`\`
01. ○ feat: session name ⚑ ⌨ [status] (5m ago)
\`\`\`

The timestamp color changes dynamically based on age, making it easy to spot stale sessions at a glance.