### PR TITLE
feat: add mouse wheel scroll support for session list

### DIFF
--- a/ui/session_list.go
+++ b/ui/session_list.go
@@ -513,6 +513,17 @@ func (sl *SessionList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return sl, nil
 		}
 
+	case tea.MouseMsg:
+		// Handle mouse wheel scrolling
+		switch msg.Type {
+		case tea.MouseWheelUp:
+			sl.list.CursorUp()
+			return sl, nil
+		case tea.MouseWheelDown:
+			sl.list.CursorDown()
+			return sl, nil
+		}
+
 	case tea.WindowSizeMsg:
 		// Store dimensions
 		sl.width = msg.Width


### PR DESCRIPTION
## Summary

- Adds mouse wheel scrolling to navigate through the session list
- Uses existing bubbletea mouse support that was already enabled
- Mouse wheel up/down events call CursorUp/Down on the list model

## Test plan

- [ ] Run `rocha-feat-mouse-wheel-scroll-v1 --dev` to start the application
- [ ] Verify the version shows "feat-mouse-wheel-scroll-v1" in the header
- [ ] Use mouse wheel to scroll up through the session list
- [ ] Use mouse wheel to scroll down through the session list
- [ ] Verify cursor selection moves smoothly with mouse wheel
- [ ] Verify keyboard navigation (arrow keys) still works
- [ ] Verify filtering mode still works correctly