### PR TITLE
feat: add dedicated help screen with keyboard shortcuts

### DIFF
--- a/ui/help_screen.go
+++ b/ui/help_screen.go
@@ -1,0 +1,112 @@
+package ui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	// Help screen styles
+	helpGroupStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("141")).
+			MarginTop(1)
+
+	helpKeyStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("205")).
+			Width(25)
+
+	helpDescStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("250"))
+)
+
+// HelpScreen displays keyboard shortcuts organized by category
+type HelpScreen struct {
+	Completed bool
+}
+
+// NewHelpScreen creates a new help screen component
+func NewHelpScreen() *HelpScreen {
+	return &HelpScreen{
+		Completed: false,
+	}
+}
+
+// Init implements tea.Model
+func (h *HelpScreen) Init() tea.Cmd {
+	return nil
+}
+
+// Update implements tea.Model
+func (h *HelpScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Handle key press
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
+		case "esc", "q", "h", "?":
+			h.Completed = true
+			return h, nil
+		}
+	}
+
+	return h, nil
+}
+
+// View implements tea.Model
+func (h *HelpScreen) View() string {
+	var content string
+
+	// Navigation
+	content += helpGroupStyle.Render("Navigation") + "\n"
+	content += h.renderShortcut("↑ / k", "Move up")
+	content += h.renderShortcut("↓ / j", "Move down")
+	content += h.renderShortcut("shift+K", "Move session up in list")
+	content += h.renderShortcut("shift+J", "Move session down in list")
+	content += h.renderShortcut("/", "Enter filter mode")
+	content += h.renderShortcut("esc", "Clear filter (press twice within 500ms)")
+
+	// Session Management
+	content += "\n" + helpGroupStyle.Render("Session Management") + "\n"
+	content += h.renderShortcut("n", "Create new session")
+	content += h.renderShortcut("r", "Rename session")
+	content += h.renderShortcut("x", "Kill session")
+
+	// Session Metadata
+	content += "\n" + helpGroupStyle.Render("Session Metadata") + "\n"
+	content += h.renderShortcut("c", "Add/edit comment (shows ⌨ indicator)")
+	content += h.renderShortcut("f", "Toggle flag (shows ⚑ indicator)")
+	content += h.renderShortcut("s", "Quick cycle through statuses")
+	content += h.renderShortcut("S (shift+S)", "Open status selection form")
+
+	// Session Actions
+	content += "\n" + helpGroupStyle.Render("Session Actions") + "\n"
+	content += h.renderShortcut("enter", "Open/attach to session")
+	content += h.renderShortcut("alt+1 through alt+7", "Quick open session by position")
+	content += h.renderShortcut("alt+enter", "Open shell session (shows >_ indicator)")
+	content += h.renderShortcut("o", "Open session in editor (requires worktree)")
+
+	// Application
+	content += "\n" + helpGroupStyle.Render("Application") + "\n"
+	content += h.renderShortcut("h / ?", "Show this help screen")
+	content += h.renderShortcut("q / ctrl+c", "Quit application")
+
+	// State Indicators
+	content += "\n" + helpGroupStyle.Render("State Indicators (read-only)") + "\n"
+	content += h.renderShortcut("●", "Session is working")
+	content += h.renderShortcut("○", "Session is idle")
+	content += h.renderShortcut("◐", "Session is waiting")
+	content += h.renderShortcut("■", "Session has exited")
+	content += h.renderShortcut("⚑", "Session has flag set")
+	content += h.renderShortcut("⌨", "Session has comment")
+	content += h.renderShortcut(">_", "Shell session active")
+	content += h.renderShortcut("[spec], [plan], etc.", "Implementation status")
+
+	// Footer instruction
+	content += "\n\n" + helpStyle.Render("Press esc, q, h, or ? to close")
+
+	return content
+}
+
+// renderShortcut renders a single shortcut line with key and description
+func (h *HelpScreen) renderShortcut(key, description string) string {
+	return helpKeyStyle.Render(key) + helpDescStyle.Render(description) + "\n"
+}

--- a/ui/session_list.go
+++ b/ui/session_list.go
@@ -238,6 +238,7 @@ type SessionList struct {
 	timestampConfig *TimestampColorConfig
 
 	// Result fields - set by component, read by Model
+	RequestHelp          bool          // User pressed 'h' or '?'
 	RequestNewSession    bool          // User pressed 'n'
 	RequestTestError     bool          // User pressed 'alt+e' (test command)
 	SelectedSession      *tmux.Session // Session user wants to attach to
@@ -404,6 +405,10 @@ func (sl *SessionList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "ctrl+c", "q":
 			sl.ShouldQuit = true
+			return sl, nil
+
+		case "h", "?":
+			sl.RequestHelp = true
 			return sl, nil
 
 		case "n":
@@ -590,7 +595,7 @@ func (sl *SessionList) View() string {
 	helpText += "n: new • r: rename • c: comment (⌨) • f: flag (⚑) • s: cycle status • shift+s: set status • x: kill\n"
 
 	// Other
-	helpText += "enter/alt+1-7: open • alt+enter: shell (>_) • o: editor • ctrl+q: to list • q: quit"
+	helpText += "enter/alt+1-7: open • alt+enter: shell (>_) • o: editor • ctrl+q: to list • h/?: help • q: quit"
 
 	s += helpStyle.Render(helpText)
 


### PR DESCRIPTION
## Summary
- Added dedicated help screen activated by `h` or `?` keys
- Displays all keyboard shortcuts organized into 6 logical categories:
  - Navigation
  - Session Management
  - Session Metadata
  - Session Actions
  - Application
  - State Indicators (read-only)
- Follows existing Dialog wrapper pattern for consistent header rendering
- Integrates seamlessly with state machine (stateHelp)
- Exit help screen with esc, q, h, or ?

## Test plan
- [ ] Press `h` in session list to open help screen
- [ ] Press `?` in session list to open help screen
- [ ] Verify all shortcuts are displayed and organized into 6 groups
- [ ] Press `esc` in help screen to return to list
- [ ] Press `q` in help screen to return to list
- [ ] Press `h` or `?` again in help to return to list
- [ ] Verify dialog header shows correctly (app name, version, tagline, "Help" title)
- [ ] Verify existing shortcuts still work after viewing help
- [ ] Verify section headers use distinct color from dialog title