### PR TITLE
feat: organize worktrees by repository in owner/repo subdirectories

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -476,9 +476,9 @@ func (s *SessionState) RemoveSession(name string) error {
 }
 
 // GetCounts returns the number of waiting, idle, and working sessions for the given execution ID
-func (s *SessionState) GetCounts(executionID string) (waiting int, idle int, working int) {
+func (s *SessionState) GetCounts(executionID string) (waiting int, idle int, working int, exited int) {
 	if s.Sessions == nil {
-		return 0, 0, 0
+		return 0, 0, 0, 0
 	}
 
 	for _, session := range s.Sessions {
@@ -493,10 +493,12 @@ func (s *SessionState) GetCounts(executionID string) (waiting int, idle int, wor
 			idle++
 		case StateWorking:
 			working++
+		case StateExited:
+			exited++
 		}
 	}
 
-	return waiting, idle, working
+	return waiting, idle, working, exited
 }
 
 // GetAllCounts returns the number of waiting, idle, and working sessions across all execution IDs

--- a/ui/session_form.go
+++ b/ui/session_form.go
@@ -257,8 +257,8 @@ func (sf *SessionForm) createSession() error {
 				worktreeBase = filepath.Join(home, worktreeBase[2:])
 			}
 
-			// Use tmux name (no spaces) for worktree directory
-			worktreePath = filepath.Join(worktreeBase, tmuxName)
+			// Build worktree path with repository organization
+			worktreePath = git.BuildWorktreePath(worktreeBase, repoInfo, tmuxName)
 			logging.Logger.Info("Creating worktree", "path", worktreePath, "branch", branchName)
 
 			// Create the worktree


### PR DESCRIPTION
## Summary

Refactors worktree storage to organize them by repository, improving project organization:

- **New structure:** `~/.rocha/worktrees/owner/repo/session-name` (e.g., `~/.rocha/worktrees/renato0307/rocha/my-feature`)
- **Fallback:** Falls back to flat structure `~/.rocha/worktrees/session-name` for non-GitHub repos
- **Backward compatible:** Existing worktrees in old flat structure continue to work without migration

### Implementation Details

- Added `BuildWorktreePath()` function in `git/worktree.go` for centralized path construction
- Added `sanitizePathComponent()` for safe filesystem path handling
- Updated `ui/session_form.go` to use new path construction
- Fixed `GetCounts()` in `state/state.go` to return exited session count (fixes test failure)

### Benefits

- Better organization when working with multiple repositories
- Easy to identify which worktrees belong to which project
- No breaking changes - existing sessions work as-is

## Test Plan

- [x] Built and tested binary with version info
- [x] Created new worktree - verified it uses `owner/repo/session` structure
- [x] Verified old worktrees still work (backward compatibility)
- [x] Tested path sanitization for safe filesystem usage
- [x] Fixed `GetCounts()` test failure

Tested with: `rocha-refactor-store-worktrees-in-subdirectory-with-the-repo-name-v1`