### PR TITLE
feat: enhance help text readability with distinct shortcut styling

### DIFF
--- a/ui/help_screen.go
+++ b/ui/help_screen.go
@@ -13,11 +13,12 @@ var (
 			MarginTop(1)
 
 	helpKeyStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("205")).
+			Foreground(lipgloss.Color("255")).
+			Bold(true).
 			Width(25)
 
 	helpDescStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("250"))
+			Foreground(lipgloss.Color("245"))
 )
 
 // HelpScreen displays keyboard shortcuts organized by category

--- a/ui/model.go
+++ b/ui/model.go
@@ -30,6 +30,13 @@ var (
 			Foreground(lipgloss.Color("241")).
 			Padding(1, 0)
 
+	helpShortcutStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("255")).
+				Bold(true)
+
+	helpLabelStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("245"))
+
 	branchStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("241")) // Dimmed/gray
 

--- a/ui/session_list.go
+++ b/ui/session_list.go
@@ -596,13 +596,13 @@ func (sl *SessionList) View() string {
 	helpText := sl.renderStatusLegend() + "\n\n"
 
 	// Movement
-	helpText += "↑/k: up • ↓/j: down • shift+↑/k: move up • shift+↓/j: move down • /: filter • t: timestamps\n"
+	helpText += formatHelpLine("↑/k: up • ↓/j: down • shift+↑/k: move up • shift+↓/j: move down • /: filter • t: timestamps") + "\n"
 
 	// Actions
-	helpText += "n: new • r: rename • c: comment (⌨) • f: flag (⚑) • a: archive • s: cycle status • shift+s: set status • x: kill\n"
+	helpText += formatHelpLine("n: new • r: rename • c: comment (⌨) • f: flag (⚑) • a: archive • s: cycle status • shift+s: set status • x: kill") + "\n"
 
 	// Other
-	helpText += "enter/alt+1-7: open • alt+enter: shell (>_) • o: editor • ctrl+q: to list • h/?: help • q: quit"
+	helpText += formatHelpLine("enter/alt+1-7: open • alt+enter: shell (>_) • o: editor • ctrl+q: to list • h/?: help • q: quit")
 
 	s += helpStyle.Render(helpText)
 
@@ -769,6 +769,35 @@ func (sl *SessionList) countSessionsByState() (working, idle, waiting, exited in
 		}
 	}
 	return
+}
+
+// formatHelpLine formats a help line with styled shortcuts and labels
+func formatHelpLine(line string) string {
+	// Split by bullet separator
+	parts := strings.Split(line, " • ")
+	var formatted []string
+
+	for _, part := range parts {
+		// Split by colon to separate shortcut from label
+		colonIdx := strings.Index(part, ": ")
+		if colonIdx == -1 {
+			// No colon found, just render as-is
+			formatted = append(formatted, part)
+			continue
+		}
+
+		shortcut := part[:colonIdx]
+		label := part[colonIdx+2:] // +2 to skip ": "
+
+		// Style shortcut and label separately
+		styledShortcut := helpShortcutStyle.Render(shortcut)
+		styledLabel := helpLabelStyle.Render(": " + label)
+
+		formatted = append(formatted, styledShortcut+styledLabel)
+	}
+
+	// Join back with bullet separator
+	return strings.Join(formatted, " • ")
 }
 
 // ensureSessionExists checks if a session exists and recreates it if needed


### PR DESCRIPTION
## Summary
- Improved visual hierarchy in help screen and session list help bar
- Keyboard shortcuts now appear in bold white (255) for high visibility
- Labels appear in dimmer gray (245) for clear distinction
- Makes it easier to quickly scan and identify available actions

## Test plan
- [x] Run the application and view the session list help bar
- [x] Press `h` or `?` to view the help screen
- [x] Verify shortcuts are clearly distinguished from labels with appropriate contrast