### PR TITLE
feat: add shift+arrow key support for session reordering

### DIFF
--- a/ui/keys_navigation.go
+++ b/ui/keys_navigation.go
@@ -28,11 +28,11 @@ func newNavigationKeys() NavigationKeys {
 			key.WithHelp("/", "filter"),
 		),
 		MoveDown: key.NewBinding(
-			key.WithKeys("J"),
+			key.WithKeys("J", "shift+down"),
 			key.WithHelp("shift+↓/j", "move session down"),
 		),
 		MoveUp: key.NewBinding(
-			key.WithKeys("K"),
+			key.WithKeys("K", "shift+up"),
 			key.WithHelp("shift+↑/k", "move session up"),
 		),
 		Up: key.NewBinding(


### PR DESCRIPTION
## Summary

Adds support for shift+up and shift+down keyboard shortcuts for moving sessions up and down in the session list.

- Extends `MoveUp` key binding to include `shift+up` alongside existing `K` (shift+K)
- Extends `MoveDown` key binding to include `shift+down` alongside existing `J` (shift+J)
- Maintains backward compatibility with vim-style shortcuts (shift+K/J)
- Improves accessibility by supporting standard arrow key modifiers

## Changes

- `ui/keys_navigation.go`: Added "shift+up" and "shift+down" to navigation key bindings

## Test Plan

- [ ] Press **Shift+↑** on a session → moves session up
- [ ] Press **Shift+↓** on a session → moves session down
- [ ] Press **Shift+K** → still moves session up (backward compat)
- [ ] Press **Shift+J** → still moves session down (backward compat)
- [ ] Try at list boundaries → handles gracefully
- [ ] Verify order persists after restarting rocha