### PR TITLE
feat: add viewport scrolling to help screen

### DIFF
--- a/ui/model.go
+++ b/ui/model.go
@@ -374,7 +374,11 @@ func (m *Model) updateList(msg tea.Msg) (tea.Model, tea.Cmd) {
 		contentForm := NewHelpScreen(&m.keys)
 		m.helpScreen = NewDialog("Help", contentForm, m.devMode)
 		m.state = stateHelp
-		return m, m.helpScreen.Init()
+		// Send initial WindowSizeMsg so viewport can initialize
+		initCmd := m.helpScreen.Init()
+		updatedDialog, sizeCmd := m.helpScreen.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height})
+		m.helpScreen = updatedDialog.(*Dialog)
+		return m, tea.Batch(initCmd, sizeCmd)
 	}
 
 	if m.sessionList.RequestNewSession {


### PR DESCRIPTION
## Summary

Adds viewport scrolling to the help screen to handle content that exceeds typical terminal heights. The help screen contains 42+ lines of content which doesn't fit in standard 24-40 line terminals.

### Changes
- Integrated `bubbles/viewport` component for scrollable content
- Extracted content building into `buildHelpContent()` for one-time generation
- Added viewport initialization with arrow keys (↑↓) and vim keys (j/k)
- Implemented `WindowSizeMsg` handling for dynamic viewport sizing
- Send initial `WindowSizeMsg` when creating help dialog for proper initialization
- Updated footer to display scroll controls

### Supported Controls
- **Arrow keys**: ↑/↓ navigation
- **Vim keys**: j/k navigation  
- **Page navigation**: PgUp/PgDn for fast scrolling
- **Jump controls**: Home/End to jump to top/bottom
- **Mouse wheel**: Scroll support (if terminal supports it)
- **Exit keys**: esc/q/h/? to close (unchanged)

## Test Plan

**Basic scrolling:**
- [ ] Run rocha in dev mode
- [ ] Press `h` to open help screen
- [ ] Use ↑/↓ arrow keys to scroll through content
- [ ] Verify all help content is visible and scrollable
- [ ] Verify footer remains visible at bottom

**Keyboard controls:**
- [ ] Test j/k vim-style navigation
- [ ] Test Page Up/Down for fast scrolling
- [ ] Test Home/End to jump to top/bottom
- [ ] Verify all controls work smoothly

**Mouse scrolling:**
- [ ] Test mouse wheel up/down
- [ ] Verify scroll position updates correctly

**Exit behavior:**
- [ ] Test all exit keys: esc, q, h, ?
- [ ] Verify each key closes help and returns to session list

**Window resize:**
- [ ] Open help screen and scroll to middle
- [ ] Resize terminal smaller and larger
- [ ] Verify viewport adjusts height correctly
- [ ] Verify content remains readable

**Edge cases:**
- [ ] Test in very small terminal (20x10)
- [ ] Test in very large terminal  
- [ ] Verify no crashes or visual glitches