### PR TITLE
docs: add tmux shortcuts to help screen and standardize to lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,26 +45,27 @@ For all available commands and options, run `rocha --help`.
 ## Key Bindings
 
 **In the list:**
-- `n` - New session
-- `Enter` - Attach to session
-- `alt+1` to `alt+7` - Quick attach to sessions by number
-- `alt+enter` - Open shell session (⌨) for the selected session
-- `r` - Rename session
-- `c` - Add/edit comment on session
-- `f` - Toggle flag (mark session as important)
-- `s` - Cycle through statuses quickly (working → idle → waiting → exited)
-- `shift+s` - Set status (interactive form to choose status)
-- `o` - Open session in your editor
-- `x` - Kill session
-- `↑/↓` or `j/k` - Navigate
-- `shift+↑/↓` or `shift+j/k` - Move session up/down in list
-- `/` - Filter/search sessions
-- `esc` (twice) - Clear filter
-- `q` - Quit
+- `n` - new session
+- `enter` - attach to session
+- `alt+1` to `alt+7` - quick attach to sessions by number
+- `alt+enter` - open shell session (⌨) for the selected session
+- `r` - rename session
+- `c` - add/edit comment on session
+- `f` - toggle flag (mark session as important)
+- `s` - cycle through statuses quickly (working → idle → waiting → exited)
+- `shift+s` - set status (interactive form to choose status)
+- `o` - open session in your editor
+- `x` - kill session
+- `↑/↓` or `j/k` - navigate
+- `shift+↑/↓` or `shift+j/k` - move session up/down in list
+- `/` - filter/search sessions
+- `esc` (twice) - clear filter
+- `q` - quit
 
 **Inside a session:**
-- `Ctrl+Q` - Quick return to list
-- `Ctrl+B then D` - Standard tmux detach (also works)
+- `ctrl+q` - quick return to list
+- `ctrl+]` - swap between claude and shell sessions
+- `ctrl+b then d` - standard tmux detach (also works)
 
 ## Git Worktree Support
 

--- a/ui/help_screen.go
+++ b/ui/help_screen.go
@@ -74,6 +74,12 @@ func buildHelpContent(keys *KeyMap) string {
 	content += renderBinding(keys.SessionActions.OpenShell)
 	content += renderBinding(keys.SessionActions.OpenEditor)
 
+	// Inside Session Shortcuts (tmux-level)
+	content += "\n" + helpGroupStyle.Render("Inside Session Shortcuts") + "\n"
+	content += renderShortcut("ctrl+q", "quick return to list")
+	content += renderShortcut("ctrl+]", "swap between claude and shell sessions")
+	content += renderShortcut("ctrl+b then d", "standard tmux detach (also works)")
+
 	// Application
 	content += "\n" + helpGroupStyle.Render("Application") + "\n"
 	content += renderBinding(keys.Application.Timestamps)
@@ -83,14 +89,14 @@ func buildHelpContent(keys *KeyMap) string {
 
 	// State Indicators
 	content += "\n" + helpGroupStyle.Render("State Indicators (read-only)") + "\n"
-	content += renderShortcut("●", "Session is working")
-	content += renderShortcut("○", "Session is idle")
-	content += renderShortcut("◐", "Session is waiting")
-	content += renderShortcut("■", "Session has exited")
-	content += renderShortcut("⚑", "Session has flag set")
-	content += renderShortcut("⌨", "Session has comment")
-	content += renderShortcut(">_", "Shell session active")
-	content += renderShortcut("[spec], [plan], etc.", "Implementation status")
+	content += renderShortcut("●", "session is working")
+	content += renderShortcut("○", "session is idle")
+	content += renderShortcut("◐", "session is waiting")
+	content += renderShortcut("■", "session has exited")
+	content += renderShortcut("⚑", "session has flag set")
+	content += renderShortcut("⌨", "session has comment")
+	content += renderShortcut(">_", "shell session active")
+	content += renderShortcut("[spec], [plan], etc.", "implementation status")
 
 	return content
 }


### PR DESCRIPTION
## Summary

- Adds "Inside Session Shortcuts" section to help screen documenting tmux-level keyboard shortcuts
- Standardizes all keyboard shortcuts and descriptions to lowercase across help screen and README
- Improves discoverability of ctrl+q, ctrl+], and ctrl+b shortcuts

## Changes

### Help Screen (`ui/help_screen.go`)
- Added new "Inside Session Shortcuts" section with:
  - `ctrl+q` - quick return to list
  - `ctrl+]` - swap between claude and shell sessions
  - `ctrl+b then d` - standard tmux detach (also works)
- Standardized all state indicator descriptions to lowercase
- Standardized all shortcut descriptions to lowercase

### README.md
- Standardized all keyboard shortcuts to lowercase format
- Standardized all descriptions to lowercase
- Ensures consistency across documentation

## Motivation

The tmux-level shortcuts (ctrl+q and ctrl+]) are part of the core UX but were missing from the help screen. Users needed to discover these shortcuts through the README or trial and error. This change makes them visible in the built-in help (h/?) for better discoverability.

Additionally, standardizing to lowercase improves visual consistency and readability.

## Test Plan

- [ ] Build and run rocha
- [ ] Press `h` or `?` to open help screen
- [ ] Verify "Inside Session Shortcuts" section appears
- [ ] Verify all shortcuts and descriptions are lowercase
- [ ] Verify help screen is scrollable and readable