### PR TITLE
fix: use non-blocking sound playback in notify command

### DIFF
--- a/sound/player_darwin.go
+++ b/sound/player_darwin.go
@@ -35,7 +35,7 @@ func playForEvent(eventType string) error {
 	// Try each sound file
 	for _, soundFile := range soundFiles {
 		cmd := exec.Command("afplay", soundFile)
-		if err := cmd.Run(); err == nil {
+		if err := cmd.Start(); err == nil {
 			return nil
 		}
 	}

--- a/sound/player_linux.go
+++ b/sound/player_linux.go
@@ -53,7 +53,7 @@ func playForEvent(eventType string) error {
 
 	for _, sound := range sounds {
 		cmd := exec.Command(sound.cmd, sound.args...)
-		if err := cmd.Run(); err == nil {
+		if err := cmd.Start(); err == nil {
 			return nil
 		}
 	}

--- a/sound/player_windows.go
+++ b/sound/player_windows.go
@@ -34,7 +34,7 @@ func playForEvent(eventType string) error {
 
 	for _, soundCmd := range soundCommands {
 		cmd := exec.Command("powershell", "-c", soundCmd)
-		if err := cmd.Run(); err == nil {
+		if err := cmd.Start(); err == nil {
 			return nil
 		}
 	}


### PR DESCRIPTION
## Summary
- Changed sound playback from `cmd.Run()` to `cmd.Start()` to prevent blocking
- Reduces notify command execution time from ~2.4s to ~50ms (98% improvement)
- Applied to all platform implementations (macOS, Linux, Windows)

## Problem
The `rocha notify` command was taking 2.45 seconds to execute because it blocked waiting for sound files (1.5-1.6s duration) to finish playing before continuing.

## Solution
Use asynchronous sound playback by calling `cmd.Start()` instead of `cmd.Run()`, allowing the notify command to return immediately while the sound plays in the background.

## Testing
Verified on macOS that sound still plays correctly and command execution time dropped from 2.45s to ~50ms.