### PR TITLE
fix: correct session state tracking for idle vs waiting states

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,38 @@ For all available commands and options, run `rocha --help`.
 - **Git worktree support** - Each session can have its own isolated branch and workspace
 - **Git stats** - See PR info, ahead/behind commits, and changes at a glance
 
+## Session States
+
+Rocha automatically tracks the state of each Claude session using hooks:
+
+### State Symbols
+
+- **● (green)** - **Working**: Claude is actively processing a task
+- **○ (yellow)** - **Idle**: Claude finished its turn, ready for your next prompt
+- **◐ (red)** - **Waiting**: Claude is blocked on a UI interaction (form, permission dialog)
+- **■ (gray)** - **Exited**: Claude has exited the session
+
+### State Transitions
+
+```
+User submits prompt → working (●)
+Claude finishes task → idle (○)
+Claude shows AskUserQuestion form → waiting (◐)
+User answers form → working (●)
+Claude needs permission → waiting (◐)
+Claude exits → exited (■)
+```
+
+### Key Differences
+
+**idle (○) vs waiting (◐)**:
+- **idle**: Claude finished, you type your next message in chat
+- **waiting**: Claude is blocked on a UI element (form with buttons, permission dialog)
+
+For example:
+- Claude asks "What color?" in text → **idle (○)** (normal chat)
+- Claude shows `[○ Red] [○ Blue]` form → **waiting (◐)** (blocking UI)
+
 ## Key Bindings
 
 **In the list:**

--- a/cmd/start_claude.go
+++ b/cmd/start_claude.go
@@ -107,17 +107,8 @@ func (s *StartClaudeCmd) Run(cli *CLI) error {
 					},
 				},
 			},
-			// Notification: Catch idle_prompt and permission_prompt (when Claude truly needs user input)
+			// Notification: Catch permission_prompt (when Claude needs user permission)
 			"Notification": []map[string]interface{}{
-				{
-					"matcher": "idle_prompt",
-					"hooks": []map[string]interface{}{
-						{
-							"type":    "command",
-							"command": fmt.Sprintf("%s notify %s notification --execution-id=%s", rochaBin, sessionName, executionID),
-						},
-					},
-				},
 				{
 					"matcher": "permission_prompt",
 					"hooks": []map[string]interface{}{
@@ -135,6 +126,18 @@ func (s *StartClaudeCmd) Run(cli *CLI) error {
 						{
 							"type":    "command",
 							"command": fmt.Sprintf("%s notify %s end --execution-id=%s", rochaBin, sessionName, executionID),
+						},
+					},
+				},
+			},
+			// PreToolUse: When Claude is about to ask user a question
+			"PreToolUse": []map[string]interface{}{
+				{
+					"matcher": "AskUserQuestion",
+					"hooks": []map[string]interface{}{
+						{
+							"type":    "command",
+							"command": fmt.Sprintf("%s notify %s notification --execution-id=%s", rochaBin, sessionName, executionID),
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

Fixes incorrect session state tracking where sessions appeared as "waiting" (◐) after successfully completing tasks.

### Root Cause

Sessions were incorrectly showing as "waiting" after 60 seconds of inactivity because:

1. **`idle_prompt` notification** fires after 60s timeout (not an actual request for input)
2. Both `idle_prompt` and `permission_prompt` were mapped to the same "waiting" state
3. **Missing PreToolUse hook** for `AskUserQuestion` meant state didn't change when Claude actually asked questions

### Changes

**Removed `idle_prompt` hook:**
- `idle_prompt` is just a 60-second timeout notification, not a "waiting for user" state
- Sessions now stay in `idle` (○) after completing instead of incorrectly showing `waiting` (◐)

**Added `PreToolUse` hook for `AskUserQuestion`:**
- Before: When Claude asks a question → state = `working` (●) until user answers
- After: When Claude asks a question → state = `waiting` (◐) until user answers
- User answers → `PostToolUse` fires → state = `working` (●)

**Kept `permission_prompt` hook:**
- Correctly sets state to `waiting` (◐) when Claude needs permission to run a tool

**Added documentation:**
- Documented session states and state transitions in README.md
- Clarified difference between idle and waiting states

### State Transitions (After Fix)

```
User submits prompt → working (●)
Claude finishes task → idle (○)
Claude shows AskUserQuestion form → waiting (◐)
User answers form → working (●)
Claude needs permission → waiting (◐)
Claude exits → exited (■)
```

### Testing

Built and tested locally with version injection:
```bash
go build -ldflags="-X rocha/version.Version=fix-update-failing-v1 ..." -o ~/.local/bin/rocha-fix-update-failing-v1
```

## Test Plan

- [ ] Create a session and submit a prompt
- [ ] Verify state changes from idle → working → idle
- [ ] Test AskUserQuestion tool to verify waiting state appears when form is shown
- [ ] Verify session stays in idle state after 60+ seconds (no incorrect waiting state)
- [ ] Test permission prompts to verify waiting state