### PR TITLE
feat: add configurable tmux status bar position

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -117,6 +117,7 @@ type RunCmd struct {
 	TimestampStaleColor     string `help:"ANSI color code for stale timestamps (matches waiting state ◐)" default:"1"`
 	TimestampWarningColor   string `help:"ANSI color code for warning timestamps (matches idle state ○)" default:"3"`
 	TimestampWarningMinutes int    `help:"Minutes threshold for warning timestamps (yellow color)" default:"20"`
+	TmuxStatusPosition      string `help:"Tmux status bar position (top or bottom)" default:"bottom" enum:"top,bottom"`
 	WorktreePath            string `help:"Base directory for git worktrees" type:"path" default:"~/.rocha/worktrees"`
 }
 
@@ -170,6 +171,15 @@ func (r *RunCmd) Run(tmuxClient tmux.Client, cli *CLI) error {
 			if _, hasEnv := os.LookupEnv("ROCHA_SHOW_TIMESTAMPS"); !hasEnv {
 				if cli.settings.ShowTimestamps != nil && *cli.settings.ShowTimestamps {
 					r.ShowTimestamps = true
+				}
+			}
+		}
+
+		// Apply TmuxStatusPosition setting
+		if r.TmuxStatusPosition == tmux.DefaultStatusPosition {
+			if _, hasEnv := os.LookupEnv("ROCHA_TMUX_STATUS_POSITION"); !hasEnv {
+				if cli.settings.TmuxStatusPosition != "" {
+					r.TmuxStatusPosition = cli.settings.TmuxStatusPosition
 				}
 			}
 		}
@@ -246,7 +256,7 @@ func (r *RunCmd) Run(tmuxClient tmux.Client, cli *CLI) error {
 		r.TimestampStaleColor,
 	)
 	p := tea.NewProgram(
-		ui.NewModel(tmuxClient, store, r.WorktreePath, r.Editor, errorClearDelay, statusConfig, timestampConfig, r.Dev, r.ShowTimestamps),
+		ui.NewModel(tmuxClient, store, r.WorktreePath, r.Editor, errorClearDelay, statusConfig, timestampConfig, r.Dev, r.ShowTimestamps, r.TmuxStatusPosition),
 		tea.WithAltScreen(),       // Use alternate screen buffer
 		tea.WithMouseCellMotion(), // Enable mouse support
 	)

--- a/config/settings.go
+++ b/config/settings.go
@@ -15,10 +15,11 @@ type Settings struct {
 	Editor          string      `json:"editor,omitempty"`
 	ErrorClearDelay *int        `json:"error_clear_delay,omitempty"`
 	MaxLogFiles     *int        `json:"max_log_files,omitempty"`
-	ShowTimestamps  *bool       `json:"show_timestamps,omitempty"`
-	StatusColors    StringArray `json:"status_colors,omitempty"`
-	Statuses        StringArray `json:"statuses,omitempty"`
-	WorktreePath    string      `json:"worktree_path,omitempty"`
+	ShowTimestamps     *bool       `json:"show_timestamps,omitempty"`
+	StatusColors       StringArray `json:"status_colors,omitempty"`
+	Statuses           StringArray `json:"statuses,omitempty"`
+	TmuxStatusPosition string      `json:"tmux_status_position,omitempty"`
+	WorktreePath       string      `json:"worktree_path,omitempty"`
 }
 
 // StringArray supports both JSON arrays and comma-separated strings

--- a/tmux/interface.go
+++ b/tmux/interface.go
@@ -15,8 +15,8 @@ var (
 
 // SessionManager handles session lifecycle operations
 type SessionManager interface {
-	Create(name string, worktreePath string) (*Session, error)
-	CreateShellSession(name string, worktreePath string) (*Session, error)
+	Create(name string, worktreePath string, statusPosition string) (*Session, error)
+	CreateShellSession(name string, worktreePath string, statusPosition string) (*Session, error)
 	Exists(name string) bool
 	List() ([]*Session, error)
 	Kill(name string) error
@@ -41,8 +41,9 @@ type PaneOperations interface {
 
 // Configurator handles tmux configuration operations
 type Configurator interface {
-	SourceFile(configPath string) error
 	BindKey(table, key, command string) error
+	SetOption(sessionName, option, value string) error
+	SourceFile(configPath string) error
 }
 
 // Client is a composite interface for commands that need multiple operations

--- a/tmux/session.go
+++ b/tmux/session.go
@@ -4,6 +4,11 @@ import (
 	"time"
 )
 
+const (
+	// DefaultStatusPosition is the default tmux status bar position
+	DefaultStatusPosition = "bottom"
+)
+
 // Session represents a tmux session (data-only struct)
 type Session struct {
 	Name      string
@@ -17,7 +22,7 @@ var defaultClient = NewClient()
 // If worktreePath is provided (non-empty), the session will start in that directory
 // This is a backward-compatible wrapper around DefaultClient.Create
 func NewSession(name string, worktreePath string) (*Session, error) {
-	return defaultClient.Create(name, worktreePath)
+	return defaultClient.Create(name, worktreePath, DefaultStatusPosition)
 }
 
 // List returns all active tmux sessions

--- a/ui/session_form.go
+++ b/ui/session_form.go
@@ -35,20 +35,21 @@ type SessionFormResult struct {
 
 // SessionForm is a Bubble Tea component for creating sessions
 type SessionForm struct {
-	Completed      bool // Exported so Model can check completion
-	cancelled      bool
-	creating       bool // True when session creation is in progress
-	form           *huh.Form
-	result         SessionFormResult
-	sessionManager tmux.SessionManager
-	sessionState   *storage.SessionState
-	spinner        spinner.Model
-	store          *storage.Store
-	worktreePath   string
+	Completed          bool // Exported so Model can check completion
+	cancelled          bool
+	creating           bool // True when session creation is in progress
+	form               *huh.Form
+	result             SessionFormResult
+	sessionManager     tmux.SessionManager
+	sessionState       *storage.SessionState
+	spinner            spinner.Model
+	store              *storage.Store
+	tmuxStatusPosition string
+	worktreePath       string
 }
 
 // NewSessionForm creates a new session creation form
-func NewSessionForm(sessionManager tmux.SessionManager, store *storage.Store, worktreePath string, sessionState *storage.SessionState) *SessionForm {
+func NewSessionForm(sessionManager tmux.SessionManager, store *storage.Store, worktreePath string, sessionState *storage.SessionState, tmuxStatusPosition string) *SessionForm {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
@@ -57,11 +58,12 @@ func NewSessionForm(sessionManager tmux.SessionManager, store *storage.Store, wo
 		result: SessionFormResult{
 			CreateWorktree: true, // Default to true
 		},
-		sessionManager: sessionManager,
-		sessionState:   sessionState,
-		spinner:        s,
-		store:          store,
-		worktreePath:   worktreePath,
+		sessionManager:     sessionManager,
+		sessionState:       sessionState,
+		spinner:            s,
+		store:              store,
+		tmuxStatusPosition: tmuxStatusPosition,
+		worktreePath:       worktreePath,
 	}
 
 	// Check if we're in a git repository
@@ -269,7 +271,7 @@ func (sf *SessionForm) createSession() error {
 	}
 
 	// Create tmux session
-	session, err := sf.sessionManager.Create(tmuxName, worktreePath)
+	session, err := sf.sessionManager.Create(tmuxName, worktreePath, sf.tmuxStatusPosition)
 	if err != nil {
 		return fmt.Errorf("failed to create session: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Adds configuration for tmux status bar position (top or bottom)
- Default position is bottom
- Applies only to rocha-created sessions, not all tmux sessions

## Configuration Options
**Settings file** (`~/.rocha/settings.json`):
```json
{
  "tmux_status_position": "top"
}
```

**CLI flag**:
```bash
rocha --tmux-status-position top
rocha attach --tmux-status-position top
```

**Environment variable**:
```bash
export ROCHA_TMUX_STATUS_POSITION=top
```

## Configuration Precedence
1. CLI flag (`--tmux-status-position`)
2. Environment variable (`ROCHA_TMUX_STATUS_POSITION`)
3. Settings file (`tmux_status_position`)
4. Default (`bottom`)

## Implementation Details
- Uses session-specific tmux options (`-t <session>`) instead of global (`-g`) to avoid affecting other tmux sessions
- Passes status position through all session creation paths (TUI, attach command, shell sessions)
- Added `DefaultStatusPosition` constant to avoid hardcoded strings

## Test plan
- [ ] Test default behavior (status bar at bottom)
- [ ] Test CLI flag: `rocha --tmux-status-position top --dev`
- [ ] Test settings.json configuration
- [ ] Test attach command: `rocha attach --tmux-status-position top`
- [ ] Verify it only affects rocha sessions, not other tmux sessions
- [ ] Test precedence order (CLI > env > settings > default)