### PR TITLE
feat: add support for --allow-dangerously-skip-permissions flag

### DIFF
--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -18,11 +18,12 @@ import (
 
 // AttachCmd attaches to a tmux session, creating it if needed
 type AttachCmd struct {
-	Branch             string `help:"Override branch name (default: auto-detect from git)"`
-	Repo               string `help:"Override repository path (default: auto-detect)"`
-	SessionName        string `help:"Override session name (default: auto-detect from branch/directory)"`
-	TmuxStatusPosition string `help:"Tmux status bar position (top or bottom)" default:"bottom" enum:"top,bottom"`
-	Worktree           string `help:"Override worktree path (default: current directory)"`
+	AllowDangerouslySkipPermissions bool   `help:"Skip permission prompts in Claude (DANGEROUS - use with caution)"`
+	Branch                          string `help:"Override branch name (default: auto-detect from git)"`
+	Repo                            string `help:"Override repository path (default: auto-detect)"`
+	SessionName                     string `help:"Override session name (default: auto-detect from branch/directory)"`
+	TmuxStatusPosition              string `help:"Tmux status bar position (top or bottom)" default:"bottom" enum:"top,bottom"`
+	Worktree                        string `help:"Override worktree path (default: current directory)"`
 }
 
 // Run executes the attach command
@@ -174,15 +175,16 @@ func (a *AttachCmd) Run(tmuxClient tmux.Client, cli *CLI) error {
 		logging.Logger.Info("Creating new session with execution ID", "execution_id", executionID)
 
 		sessionInfo = storage.SessionInfo{
-			Name:         sessionName,
-			DisplayName:  sessionName,
-			State:        state.StateIdle,
-			ExecutionID:  executionID,
-			LastUpdated:  time.Now().UTC(),
-			BranchName:   branchName,
-			WorktreePath: worktreePath,
-			RepoPath:     repoPath,
-			RepoInfo:     repoInfo,
+			AllowDangerouslySkipPermissions: a.AllowDangerouslySkipPermissions,
+			BranchName:                      branchName,
+			DisplayName:                     sessionName,
+			ExecutionID:                     executionID,
+			LastUpdated:                     time.Now().UTC(),
+			Name:                            sessionName,
+			RepoInfo:                        repoInfo,
+			RepoPath:                        repoPath,
+			State:                           state.StateIdle,
+			WorktreePath:                    worktreePath,
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -244,6 +244,12 @@ func (r *RunCmd) Run(tmuxClient tmux.Client, cli *CLI) error {
 		}
 	}
 
+	// Extract allow dangerously skip permissions default from settings
+	allowDangerouslySkipPermissionsDefault := false
+	if cli.settings != nil && cli.settings.AllowDangerouslySkipPermissions != nil {
+		allowDangerouslySkipPermissionsDefault = *cli.settings.AllowDangerouslySkipPermissions
+	}
+
 	// Set terminal to raw mode for proper input handling
 	logging.Logger.Debug("Initializing Bubble Tea program")
 	errorClearDelay := time.Duration(r.ErrorClearDelay) * time.Second
@@ -256,7 +262,7 @@ func (r *RunCmd) Run(tmuxClient tmux.Client, cli *CLI) error {
 		r.TimestampStaleColor,
 	)
 	p := tea.NewProgram(
-		ui.NewModel(tmuxClient, store, r.WorktreePath, r.Editor, errorClearDelay, statusConfig, timestampConfig, r.Dev, r.ShowTimestamps, r.TmuxStatusPosition),
+		ui.NewModel(tmuxClient, store, r.WorktreePath, r.Editor, errorClearDelay, statusConfig, timestampConfig, r.Dev, r.ShowTimestamps, r.TmuxStatusPosition, allowDangerouslySkipPermissionsDefault),
 		tea.WithAltScreen(),       // Use alternate screen buffer
 		tea.WithMouseCellMotion(), // Enable mouse support
 	)

--- a/cmd/sessions.go
+++ b/cmd/sessions.go
@@ -201,13 +201,14 @@ func (s *SessionsViewCmd) Run(cli *CLI) error {
 
 // SessionsAddCmd adds a new session
 type SessionsAddCmd struct {
-	Name         string `arg:"" help:"Name of the session to add"`
-	DisplayName  string `help:"Display name for the session" default:""`
-	State        string `help:"Initial state" enum:"idle,working,waiting,exited" default:"idle"`
-	RepoPath     string `help:"Repository path" default:""`
-	RepoInfo     string `help:"Repository info" default:""`
-	BranchName   string `help:"Branch name" default:""`
-	WorktreePath string `help:"Worktree path" default:""`
+	AllowDangerouslySkipPermissions bool   `help:"Skip permission prompts in Claude (DANGEROUS)"`
+	BranchName                      string `help:"Branch name" default:""`
+	DisplayName                     string `help:"Display name for the session" default:""`
+	Name                            string `arg:"" help:"Name of the session to add"`
+	RepoInfo                        string `help:"Repository info" default:""`
+	RepoPath                        string `help:"Repository path" default:""`
+	State                           string `help:"Initial state" enum:"idle,working,waiting,exited" default:"idle"`
+	WorktreePath                    string `help:"Worktree path" default:""`
 }
 
 // Run executes the add command
@@ -224,15 +225,16 @@ func (s *SessionsAddCmd) Run(cli *CLI) error {
 	}
 
 	sessInfo := storage.SessionInfo{
-		Name:         s.Name,
-		DisplayName:  displayName,
-		State:        s.State,
-		ExecutionID:  uuid.New().String(),
-		LastUpdated:  time.Now().UTC(),
-		RepoPath:     s.RepoPath,
-		RepoInfo:     s.RepoInfo,
-		BranchName:   s.BranchName,
-		WorktreePath: s.WorktreePath,
+		AllowDangerouslySkipPermissions: s.AllowDangerouslySkipPermissions,
+		BranchName:                      s.BranchName,
+		DisplayName:                     displayName,
+		ExecutionID:                     uuid.New().String(),
+		LastUpdated:                     time.Now().UTC(),
+		Name:                            s.Name,
+		RepoInfo:                        s.RepoInfo,
+		RepoPath:                        s.RepoPath,
+		State:                           s.State,
+		WorktreePath:                    s.WorktreePath,
 	}
 
 	if err := store.AddSession(context.Background(), sessInfo); err != nil {

--- a/config/settings.go
+++ b/config/settings.go
@@ -10,16 +10,17 @@ import (
 
 // Settings represents the structure of ~/.rocha/settings.json
 type Settings struct {
-	DBPath          string      `json:"db_path,omitempty"`
-	Debug           *bool       `json:"debug,omitempty"`
-	Editor          string      `json:"editor,omitempty"`
-	ErrorClearDelay *int        `json:"error_clear_delay,omitempty"`
-	MaxLogFiles     *int        `json:"max_log_files,omitempty"`
-	ShowTimestamps     *bool       `json:"show_timestamps,omitempty"`
-	StatusColors       StringArray `json:"status_colors,omitempty"`
-	Statuses           StringArray `json:"statuses,omitempty"`
-	TmuxStatusPosition string      `json:"tmux_status_position,omitempty"`
-	WorktreePath       string      `json:"worktree_path,omitempty"`
+	AllowDangerouslySkipPermissions *bool       `json:"allow_dangerously_skip_permissions,omitempty"`
+	DBPath                          string      `json:"db_path,omitempty"`
+	Debug                           *bool       `json:"debug,omitempty"`
+	Editor                          string      `json:"editor,omitempty"`
+	ErrorClearDelay                 *int        `json:"error_clear_delay,omitempty"`
+	MaxLogFiles                     *int        `json:"max_log_files,omitempty"`
+	ShowTimestamps                  *bool       `json:"show_timestamps,omitempty"`
+	StatusColors                    StringArray `json:"status_colors,omitempty"`
+	Statuses                        StringArray `json:"statuses,omitempty"`
+	TmuxStatusPosition              string      `json:"tmux_status_position,omitempty"`
+	WorktreePath                    string      `json:"worktree_path,omitempty"`
 }
 
 // StringArray supports both JSON arrays and comma-separated strings

--- a/storage/schema.go
+++ b/storage/schema.go
@@ -57,3 +57,11 @@ type SessionArchive struct {
 	SessionName string `gorm:"primaryKey"`
 	UpdatedAt   time.Time
 }
+
+// SessionAgentCLIFlags represents CLI flags for the agent (Claude) for a session (extension table)
+type SessionAgentCLIFlags struct {
+	AllowDangerouslySkipPermissions bool   `gorm:"not null;default:false"`
+	CreatedAt                       time.Time
+	SessionName                     string `gorm:"primaryKey"`
+	UpdatedAt                       time.Time
+}

--- a/storage/types.go
+++ b/storage/types.go
@@ -10,19 +10,20 @@ type SessionState struct {
 
 // SessionInfo represents a session (compatible with old state package)
 type SessionInfo struct {
-	BranchName   string
-	Comment      string
-	DisplayName  string
-	ExecutionID  string
-	GitStats     interface{}
-	IsArchived   bool
-	IsFlagged    bool
-	LastUpdated  time.Time
-	Name         string
-	RepoInfo     string
-	RepoPath     string
-	ShellSession *SessionInfo
-	State        string
-	Status       *string // Implementation status (nil = no status set)
-	WorktreePath string
+	AllowDangerouslySkipPermissions bool
+	BranchName                      string
+	Comment                         string
+	DisplayName                     string
+	ExecutionID                     string
+	GitStats                        interface{}
+	IsArchived                      bool
+	IsFlagged                       bool
+	LastUpdated                     time.Time
+	Name                            string
+	RepoInfo                        string
+	RepoPath                        string
+	ShellSession                    *SessionInfo
+	State                           string
+	Status                          *string // Implementation status (nil = no status set)
+	WorktreePath                    string
 }

--- a/tmux/client.go
+++ b/tmux/client.go
@@ -343,8 +343,20 @@ func (c *DefaultClient) Detach(sessionName string) error {
 
 // GetAttachCommand returns an exec.Cmd configured for attaching to a session.
 // This is useful for integration with frameworks like Bubble Tea's tea.ExecProcess.
+// It unsets TMUX and TMUX_PANE environment variables to allow attaching from within tmux.
 func (c *DefaultClient) GetAttachCommand(sessionName string) *exec.Cmd {
 	cmd := exec.Command("tmux", "attach-session", "-t", sessionName)
+
+	// Copy current environment and remove TMUX variables to allow nested attach
+	env := os.Environ()
+	var cleanEnv []string
+	for _, e := range env {
+		if !strings.HasPrefix(e, "TMUX=") && !strings.HasPrefix(e, "TMUX_PANE=") {
+			cleanEnv = append(cleanEnv, e)
+		}
+	}
+	cmd.Env = cleanEnv
+
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

- Adds per-session and global configuration for Claude Code's permission bypass mode
- Implements database persistence using SessionAgentCLIFlags extension table
- Provides UI form field with clear warning during session creation
- Adds CLI flags to `attach` and `sessions add` commands
- Supports global default setting via `~/.rocha/settings.json`
- Passes flag to Claude Code when starting sessions
- Fixes tmux nested attach issue by unsetting TMUX environment variables
- Adds error handling to prevent infinite loop on attach failures

## Implementation Details

### Database Layer
- Created `SessionAgentCLIFlags` extension table following existing pattern (SessionFlag, SessionArchive)
- Added `AllowDangerouslySkipPermissions` field to `SessionInfo` struct
- Implemented CRUD operations in `store.go` with proper foreign key constraints

### UI Layer
- Added form field in session creation dialog with "DANGEROUS" warning
- Field defaults to global setting from `settings.json` or false if not configured
- Works for both git and non-git repositories

### CLI Layer
- Added `--allow-dangerously-skip-permissions` flag to `attach` command
- Added `--allow-dangerously-skip-permissions` flag to `sessions add` command
- Added `allow_dangerously_skip_permissions` setting to `settings.json`

### Integration
- Updated `start_claude.go` to read flag from session and pass to Claude Code
- Logs warning messages when dangerous mode is active

### Bug Fixes
- Fixed tmux nested session attach by unsetting TMUX/TMUX_PANE environment variables
- Added error handling in UI to prevent infinite loop when attach fails

## Safety

- Defaults to **false** (safe mode) everywhere
- Requires explicit opt-in per-session or via global setting
- Displays clear warning in form: "Skip permission prompts? (DANGEROUS)"
- Claude Code shows warning screen when bypass mode is active

## Test plan

- [ ] Build binary and verify compilation succeeds
- [ ] Create new session without flag - verify permission prompts work normally
- [ ] Create new session with flag enabled via UI - verify Claude shows bypass warning
- [ ] Use `attach --allow-dangerously-skip-permissions` - verify flag persisted to database
- [ ] Use `sessions add --allow-dangerously-skip-permissions` - verify flag stored
- [ ] Add `"allow_dangerously_skip_permissions": true` to settings.json - verify new sessions default to enabled
- [ ] Test tmux nested attach (from within tmux) - verify it works without "sessions should be nested with care" error
- [ ] Verify existing sessions without flag continue to work normally
- [ ] Check database schema created correctly with foreign key constraints