### PR TITLE
feat: add settings meta command to display available configuration options

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ type CLI struct {
 	PlaySound   PlaySoundCmd   `cmd:"play-sound" help:"Play notification sound (cross-platform)" hidden:""`
 	Notify      NotifyCmd      `cmd:"notify" help:"Handle notification event from Claude hooks" hidden:""`
 	Sessions    SessionsCmd    `cmd:"sessions" help:"Manage sessions (list, view, add, del)"`
+	Settings    SettingsCmd    `cmd:"settings" help:"Manage settings (meta)"`
 
 	// Internal field for settings (not a flag)
 	settings *config.Settings `kong:"-"`

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"rocha/config"
+	"text/tabwriter"
+)
+
+// SettingsCmd manages settings
+type SettingsCmd struct {
+	Meta SettingsMetaCmd `cmd:"meta" help:"Show settings file location and available options" default:"1"`
+}
+
+// SettingsMetaCmd displays settings metadata
+type SettingsMetaCmd struct {
+	Format string `help:"Output format: table or json" enum:"table,json" default:"table"`
+}
+
+// Run executes the meta command
+func (s *SettingsMetaCmd) Run(cli *CLI) error {
+	settingsFile := config.GetSettingsFilePath()
+	example := config.GetSettingsExample()
+
+	if s.Format == "json" {
+		output := map[string]any{
+			"settings_file": settingsFile,
+			"format":        example,
+		}
+		data, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	// Table format
+	fmt.Printf("Settings file: %s\n\n", settingsFile)
+	fmt.Println("Example settings.json:")
+	fmt.Println()
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	// Get keys in sorted order from the example map
+	// We'll print them in the order they appear in the map
+	for key, value := range example {
+		// Format the value for display
+		var valueStr string
+		switch v := value.(type) {
+		case []string:
+			// Format string arrays as JSON
+			data, _ := json.Marshal(v)
+			valueStr = string(data)
+		case string:
+			valueStr = v
+		case bool:
+			valueStr = fmt.Sprintf("%t", v)
+		case int:
+			valueStr = fmt.Sprintf("%d", v)
+		default:
+			valueStr = fmt.Sprintf("%v", v)
+		}
+
+		fmt.Fprintf(w, "%s\t%s\n", key, valueStr)
+	}
+
+	w.Flush()
+
+	fmt.Println()
+	fmt.Println("Create or edit this file to configure rocha.")
+	fmt.Println("All settings are optional and have sensible defaults.")
+
+	return nil
+}

--- a/config/meta.go
+++ b/config/meta.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+)
+
+// GetSettingsFilePath returns the path to the settings file
+func GetSettingsFilePath() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "~/.rocha/settings.json" // Fallback to unexpanded path
+	}
+	return filepath.Join(homeDir, ".rocha", "settings.json")
+}
+
+// GetSettingsExample uses reflection to generate example settings
+// This automatically stays in sync when new fields are added to Settings
+func GetSettingsExample() map[string]any {
+	var s Settings
+	t := reflect.TypeOf(s)
+	example := make(map[string]any)
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		jsonTag := field.Tag.Get("json")
+		if jsonTag == "" {
+			continue
+		}
+
+		// Extract the JSON field name (before comma)
+		jsonName := strings.Split(jsonTag, ",")[0]
+
+		// Generate example value based on field type
+		example[jsonName] = generateExampleValue(field.Type, jsonName)
+	}
+
+	return example
+}
+
+// generateExampleValue creates appropriate example values based on type and field name
+func generateExampleValue(t reflect.Type, fieldName string) any {
+	// Handle pointer types
+	if t.Kind() == reflect.Ptr {
+		elemType := t.Elem()
+		switch elemType.Kind() {
+		case reflect.Bool:
+			// Return boolean value directly (not pointer)
+			if fieldName == "debug" || fieldName == "show_timestamps" {
+				return true
+			}
+			return false
+		case reflect.Int:
+			// Return int value directly (not pointer)
+			if fieldName == "error_clear_delay" {
+				return 10
+			}
+			if fieldName == "max_log_files" {
+				return 1000
+			}
+			return 10
+		}
+	}
+
+	// Handle direct types
+	switch t.Kind() {
+	case reflect.String:
+		// Generate contextual examples based on field name
+		switch fieldName {
+		case "db_path":
+			return "~/.rocha/state.db"
+		case "editor":
+			return "code"
+		case "tmux_status_position":
+			return "bottom"
+		case "worktree_path":
+			return "~/.rocha/worktrees"
+		default:
+			return "example"
+		}
+	case reflect.Slice:
+		// Check if it's StringArray type
+		if t.Name() == "StringArray" || (t.Elem().Kind() == reflect.String) {
+			switch fieldName {
+			case "status_colors":
+				return []string{"141", "33", "214"}
+			case "statuses":
+				return []string{"spec", "plan", "implement"}
+			default:
+				return []string{"example1", "example2"}
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds a new `rocha settings meta` command that dynamically displays available configuration options using reflection. This command helps users discover and understand all settings without manually inspecting code or documentation.

Key features:
- Displays settings file location (`~/.rocha/settings.json`)
- Shows all available settings with contextual example values
- Supports both table (default) and JSON output formats
- Uses reflection to automatically stay in sync with the Settings struct
- No code changes needed when new settings are added

## Implementation Details

- **config/meta.go**: Reflection-based metadata extraction
  - `GetSettingsFilePath()`: Returns the settings file path
  - `GetSettingsExample()`: Uses reflection to generate example settings
  - `generateExampleValue()`: Creates appropriate example values based on field types and names

- **cmd/settings.go**: Settings command with meta subcommand
  - Table format: Human-readable output with usage instructions
  - JSON format: Structured output for programmatic use

- **cmd/root.go**: Registered Settings command in CLI struct

## Test Plan

- [x] Build binary with version flags
- [x] Test table format: `rocha settings meta`
- [x] Test JSON format: `rocha settings meta --format json`
- [x] Verify all settings from Settings struct appear in output
- [x] Verify example values are contextually appropriate
- [x] Manual testing: Run command to view settings information
- [x] Verify help text: `rocha settings --help`