### PR TITLE
fix: improve session creation and worktree management

### DIFF
--- a/config/claude_dir.go
+++ b/config/claude_dir.go
@@ -10,8 +10,15 @@ import (
 	"rocha/storage"
 )
 
-// DefaultClaudeDir returns the default Claude directory (~/.claude)
+// DefaultClaudeDir returns the default Claude directory
+// Checks CLAUDE_CONFIG_DIR environment variable first, then falls back to ~/.claude
 func DefaultClaudeDir() string {
+	// Check environment variable first
+	if envDir := os.Getenv("CLAUDE_CONFIG_DIR"); envDir != "" {
+		return paths.ExpandPath(envDir)
+	}
+
+	// Fall back to ~/.claude
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		logging.Logger.Warn("Failed to get home directory for ClaudeDir", "error", err)

--- a/git/repo.go
+++ b/git/repo.go
@@ -368,6 +368,31 @@ func isSameRepo(url1, url2 string) bool {
 		// Convert to lowercase for comparison
 		url = strings.ToLower(url)
 
+		// Normalize different URL formats to canonical form (host/owner/repo)
+		// Handle: https://github.com/owner/repo
+		if strings.HasPrefix(url, "https://") {
+			url = strings.TrimPrefix(url, "https://")
+		} else if strings.HasPrefix(url, "http://") {
+			url = strings.TrimPrefix(url, "http://")
+		}
+		// Handle: ssh://git@github.com/owner/repo
+		if strings.HasPrefix(url, "ssh://") {
+			url = strings.TrimPrefix(url, "ssh://")
+			// Remove user@ part
+			if idx := strings.Index(url, "@"); idx >= 0 {
+				url = url[idx+1:]
+			}
+		}
+		// Handle: git@github.com:owner/repo
+		if strings.Contains(url, "@") && strings.Contains(url, ":") {
+			// Format: git@host:path
+			parts := strings.SplitN(url, "@", 2)
+			if len(parts) == 2 {
+				// parts[1] is "host:path"
+				url = strings.Replace(parts[1], ":", "/", 1)
+			}
+		}
+
 		return url
 	}
 

--- a/git/worktree.go
+++ b/git/worktree.go
@@ -241,6 +241,9 @@ func sanitizePathComponent(component string) string {
 		return ""
 	}
 
+	// Convert to lowercase for consistent directory names
+	component = strings.ToLower(component)
+
 	// Remove control characters and problematic filesystem chars
 	var builder strings.Builder
 	for _, r := range component {


### PR DESCRIPTION
## Summary

Improves session creation workflow to ensure all worktrees are created from `.main` directories within rocha's structure, making sessions fully self-contained and movable between ROCHA_HOME directories.

This fixes the root cause of issues when moving sessions and improves the overall user experience.

## Changes

### Session Form (`ui/model.go`, `ui/session_form.go`)
- **Pre-fill repository field** with remote URL when starting rocha in a git folder
- **Automatic worktree creation**: Removed "Create worktree?" checkbox - worktrees are automatically created when a repo is provided
- **URL-only validation**: Repository field now only accepts git URLs (no local paths)
- **Consistent form display**: Always show suggested branch name and mark optional fields clearly

### Configuration (`config/claude_dir.go`)
- **Respect CLAUDE_CONFIG_DIR**: Default Claude directory now checks `CLAUDE_CONFIG_DIR` environment variable first
- Correctly displays user's configured directory in form placeholder

### Git Operations (`git/repo.go`, `git/worktree.go`, `operations/session_move.go`)
- **Enhanced URL comparison**: Normalize git URLs to match different formats (https, ssh, git@)
  - Example: `https://github.com/owner/repo` and `git@github.com:owner/repo.git` now match correctly
- **Lowercase worktree names**: All worktree directory names are converted to lowercase for consistency
- Fixes false "different remote URL" errors

### Move Command (`cmd/sessions.go`)
- Changed `--repos` flag to `--repo` (singular)
- Move one repository at a time with cleaner interface
- Simplified confirmation messages

## Expected Behavior

### Starting rocha in a git folder
1. Repository field pre-fills with remote URL
2. User can keep it (creates `.main` + worktree) or clear it (uses current folder)
3. Worktree automatically created in `{ROCHA_HOME}/worktrees/owner/repo/session-name`
4. All lowercase directory names

### Form consistency
- Same fields shown regardless of starting context
- Clear optional field labels
- Dynamic suggested branch name display

### Moving sessions
```bash
rocha sessions mv --from ~/.rocha_old --to ~/.rocha_new --repo owner/repo
```
- Sessions are self-contained and movable
- No "fatal: Unable to read current working directory" errors
- Move command tested and working ✓

## Test plan

- [x] Build succeeds
- [x] Pre-filling works when starting in git folder
- [x] Repository field rejects local paths
- [x] Worktrees created automatically when repo provided
- [x] CLAUDE_CONFIG_DIR environment variable respected
- [x] URL comparison handles https/ssh/git@ formats
- [x] Worktree directories are lowercase
- [x] Move command works with single repo

## Breaking Changes

None - behavior improvements only. The move command now accepts one repo at a time instead of multiple, but this simplifies the interface.