### PR TITLE
feat: add --profile flag for isolated rocha environments

### DIFF
--- a/config/claude_dir.go
+++ b/config/claude_dir.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -11,9 +12,17 @@ import (
 )
 
 // DefaultClaudeDir returns the default Claude directory
-// Checks CLAUDE_CONFIG_DIR environment variable first, then falls back to ~/.claude
+// Checks ROCHA_PROFILE first for profile-specific Claude dir, then CLAUDE_CONFIG_DIR environment variable, then falls back to ~/.claude
 func DefaultClaudeDir() string {
-	// Check environment variable first
+	// Check if profile is active and compute profile-specific Claude dir
+	if profile := os.Getenv("ROCHA_PROFILE"); profile != "" && profile != "default" {
+		homeDir, err := os.UserHomeDir()
+		if err == nil {
+			return filepath.Join(homeDir, fmt.Sprintf(".claude_%s", profile))
+		}
+	}
+
+	// Check environment variable
 	if envDir := os.Getenv("CLAUDE_CONFIG_DIR"); envDir != "" {
 		return paths.ExpandPath(envDir)
 	}

--- a/config/settings.go
+++ b/config/settings.go
@@ -16,6 +16,7 @@ type Settings struct {
 	Editor                          string      `json:"editor,omitempty"`
 	ErrorClearDelay                 *int        `json:"error_clear_delay,omitempty"`
 	MaxLogFiles                     *int        `json:"max_log_files,omitempty"`
+	Profile                         string      `json:"profile,omitempty"`
 	ShowTimestamps                  *bool       `json:"show_timestamps,omitempty"`
 	StatusColors                    StringArray `json:"status_colors,omitempty"`
 	Statuses                        StringArray `json:"statuses,omitempty"`

--- a/main.go
+++ b/main.go
@@ -3,6 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
+
 	"rocha/cmd"
 	"rocha/config"
 	"rocha/tmux"
@@ -12,7 +15,20 @@ import (
 )
 
 func main() {
-	// Load settings from ~/.rocha/settings.json
+	// PHASE 1: Bootstrap - determine profile from CLI/env only (not settings yet)
+	// This is needed because settings location depends on ROCHA_HOME, which depends on profile
+	bootstrapProfile := getBootstrapProfile()
+
+	// PHASE 2: Set ROCHA_HOME if bootstrap profile exists and is not default
+	if bootstrapProfile != "" && bootstrapProfile != "default" {
+		if _, hasEnv := os.LookupEnv("ROCHA_HOME"); !hasEnv {
+			homeDir, _ := os.UserHomeDir()
+			rochaHome := filepath.Join(homeDir, fmt.Sprintf(".rocha_%s", bootstrapProfile))
+			os.Setenv("ROCHA_HOME", rochaHome)
+		}
+	}
+
+	// PHASE 3: Now load settings from the correct ROCHA_HOME
 	settings, err := config.LoadSettings()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to load settings: %v\n", err)
@@ -41,4 +57,23 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// getBootstrapProfile manually parses CLI args for --profile flag
+// This runs before Kong parsing to determine ROCHA_HOME location
+func getBootstrapProfile() string {
+	// Check command line args manually
+	for i, arg := range os.Args {
+		if arg == "--profile" || arg == "-p" {
+			if i+1 < len(os.Args) {
+				return os.Args[i+1]
+			}
+		}
+		if strings.HasPrefix(arg, "--profile=") {
+			return strings.TrimPrefix(arg, "--profile=")
+		}
+	}
+
+	// Check environment variable
+	return os.Getenv("ROCHA_PROFILE")
 }


### PR DESCRIPTION
## Summary

Adds a global `--profile` flag that enables multiple isolated rocha environments. Each profile maintains complete separation of sessions, state, settings, and Claude configurations.

Key features:
- Profile-specific paths: `~/.rocha_<profile>` and `~/.claude_<profile>`
- Multiple ways to set profile: CLI flag, environment variable, or settings file
- Proper precedence handling: CLI flag > env var > settings file
- Backward compatible: 'default' profile uses standard paths without suffix
- Environment variables propagate to tmux sessions and Claude processes
- Debug logging shows active profile and computed paths

## Implementation Details

- **cmd/root.go**: Added Profile field to CLI struct, profile resolution logic in AfterApply()
- **config/settings.go**: Added Profile field to Settings struct
- **config/claude_dir.go**: Updated DefaultClaudeDir() to compute profile-specific paths
- **main.go**: Added bootstrap profile resolution before settings load
- **tmux/client.go**: Propagate ROCHA_PROFILE, ROCHA_HOME, and CLAUDE_CONFIG_DIR to sessions

## Test Plan

- [x] Profile flag appears in help screen
- [x] Profile via CLI flag creates correct directories
- [x] Profile via environment variable works
- [x] Multiple profiles maintain complete isolation
- [x] Default/empty profile uses standard paths
- [x] Environment variables propagate to tmux sessions
- [x] Debug logging shows profile configuration
- [x] Backward compatibility maintained (no profile = standard paths)

## Example Usage

```bash
# Work profile
rocha --profile work

# Personal profile
rocha --profile personal

# Via environment variable
export ROCHA_PROFILE=team
rocha

# Debug mode to see profile configuration
rocha --profile work --debug sessions list
```