### PR TITLE
fix(ui): sync bubbles list filter key with custom binding

### DIFF
--- a/internal/ui/session_list.go
+++ b/internal/ui/session_list.go
@@ -276,6 +276,9 @@ func NewSessionList(sessionService *services.SessionService, gitService *service
 	l.SetFilteringEnabled(true)
 	l.SetShowHelp(false) // We'll render our own help
 
+	// Sync the bubbles list's internal filter key with our custom binding
+	l.KeyMap.Filter.SetKeys(keys.Navigation.Filter.Binding.Keys()...)
+
 	// Show a tip immediately at startup if tips are enabled
 	var initialTip *Tip
 	allTips := GetTips()


### PR DESCRIPTION
## Summary
Fix ctrl+f filter shortcut not working after the keyboard shortcut swap in #151.

## Changes
- Sync the bubbles list.Model internal KeyMap.Filter with rocha's custom filter key binding

## Context
The bubbles list.Model has its own internal KeyMap.Filter that defaults to "/".
When #151 swapped the filter shortcut from "/" to "ctrl+f", only rocha's custom
KeyMap was updated but the list's internal filter trigger was never synced.